### PR TITLE
geom_alt props

### DIFF
--- a/data/421/176/527/421176527.geojson
+++ b/data/421/176/527/421176527.geojson
@@ -524,6 +524,9 @@
     },
     "wof:country":"HT",
     "wof:created":1459009111,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"362767a575c3c8cc6ea3979320cb5655",
     "wof:hierarchy":[
         {
@@ -535,7 +538,7 @@
         }
     ],
     "wof:id":421176527,
-    "wof:lastmodified":1566648900,
+    "wof:lastmodified":1582318455,
     "wof:name":"Port-au-Prince",
     "wof:parent_id":1091686735,
     "wof:placetype":"locality",

--- a/data/421/186/493/421186493.geojson
+++ b/data/421/186/493/421186493.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"HT",
     "wof:created":1459009482,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d34c5d8012618408a3e2a1228ecd194d",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":421186493,
-    "wof:lastmodified":1566648895,
+    "wof:lastmodified":1582318455,
     "wof:name":"Mirago\u00e2ne",
     "wof:parent_id":1091686629,
     "wof:placetype":"locality",

--- a/data/856/324/33/85632433.geojson
+++ b/data/856/324/33/85632433.geojson
@@ -909,7 +909,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso"
+        "meso",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -964,6 +965,11 @@
     },
     "wof:country":"HT",
     "wof:country_alpha3":"HTI",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"6ca3066290b88dbba8c96e2a5298ddfd",
     "wof:hierarchy":[
         {
@@ -980,7 +986,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1566648158,
+    "wof:lastmodified":1582318442,
     "wof:name":"Haiti",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/324/33/85632433.geojson
+++ b/data/856/324/33/85632433.geojson
@@ -909,8 +909,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -986,7 +985,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1582318442,
+    "wof:lastmodified":1583205078,
     "wof:name":"Haiti",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/719/33/85671933.geojson
+++ b/data/856/719/33/85671933.geojson
@@ -292,6 +292,9 @@
         "wd:id":"Q913231"
     },
     "wof:country":"HT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d986e537197e3f5a0b9bfe0b950e63e",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1566648161,
+    "wof:lastmodified":1582318444,
     "wof:name":"Grand'Anse",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/37/85671937.geojson
+++ b/data/856/719/37/85671937.geojson
@@ -275,6 +275,9 @@
         "wd:id":"Q125232"
     },
     "wof:country":"HT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"31352c7f1b5dd2e02b951af4ec97f6ad",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1566648162,
+    "wof:lastmodified":1582318444,
     "wof:name":"Nippes",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/41/85671941.geojson
+++ b/data/856/719/41/85671941.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Nord-Ouest (department)"
     },
     "wof:country":"HT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9e51b0e3b8329b08e1755b272799f7d0",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1566648163,
+    "wof:lastmodified":1582318444,
     "wof:name":"Nord-Ouest",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/47/85671947.geojson
+++ b/data/856/719/47/85671947.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Sud (department)"
     },
     "wof:country":"HT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64c0cd0d6494360d0f33806494b91553",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1566648164,
+    "wof:lastmodified":1582318445,
     "wof:name":"Sud",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/49/85671949.geojson
+++ b/data/856/719/49/85671949.geojson
@@ -278,6 +278,9 @@
         "wk:page":"Artibonite (department)"
     },
     "wof:country":"HT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"39f2c684782d4a0f141771588f9efb7a",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1566648163,
+    "wof:lastmodified":1582318444,
     "wof:name":"L'Artibonite",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/55/85671955.geojson
+++ b/data/856/719/55/85671955.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Centre (department)"
     },
     "wof:country":"HT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"01fe8a9e93e4b579e616a6caf347ef62",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1566648162,
+    "wof:lastmodified":1582318444,
     "wof:name":"Centre",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/57/85671957.geojson
+++ b/data/856/719/57/85671957.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Nord-Est (department)"
     },
     "wof:country":"HT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8585b9bbe8c422ae16e716f7e33822d5",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1566648160,
+    "wof:lastmodified":1582318443,
     "wof:name":"Nord-Est",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/61/85671961.geojson
+++ b/data/856/719/61/85671961.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Nord (Haitian department)"
     },
     "wof:country":"HT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e6dd8f6a1f3c5a0b99f8ac9c7f4ec89c",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1566648159,
+    "wof:lastmodified":1582318443,
     "wof:name":"Nord",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/67/85671967.geojson
+++ b/data/856/719/67/85671967.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Ouest (department)"
     },
     "wof:country":"HT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1bf64f86a4edb9e95c307997a2c2187e",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1566648160,
+    "wof:lastmodified":1582318443,
     "wof:name":"Ouest",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/69/85671969.geojson
+++ b/data/856/719/69/85671969.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Sud-Est (department)"
     },
     "wof:country":"HT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"62203499fd218449c049cb681eda5790",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1566648160,
+    "wof:lastmodified":1582318443,
     "wof:name":"Sud-Est",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/890/424/175/890424175.geojson
+++ b/data/890/424/175/890424175.geojson
@@ -63,6 +63,9 @@
     },
     "wof:country":"HT",
     "wof:created":1469051533,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"04e4d4296342be1dbf9db638efdbc6a4",
     "wof:hierarchy":[
         {
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":890424175,
-    "wof:lastmodified":1566648901,
+    "wof:lastmodified":1582318455,
     "wof:name":"Gethsemane Scholarship Inst. of Fond Des Blancs",
     "wof:parent_id":1091687293,
     "wof:placetype":"locality",

--- a/data/890/445/091/890445091.geojson
+++ b/data/890/445/091/890445091.geojson
@@ -291,6 +291,9 @@
     },
     "wof:country":"HT",
     "wof:created":1469052496,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d616cb652d4a3bacea4a28c66dcf16fd",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         }
     ],
     "wof:id":890445091,
-    "wof:lastmodified":1566648905,
+    "wof:lastmodified":1582318455,
     "wof:name":"Jacmel",
     "wof:parent_id":1091687171,
     "wof:placetype":"locality",

--- a/data/890/445/093/890445093.geojson
+++ b/data/890/445/093/890445093.geojson
@@ -264,6 +264,9 @@
     },
     "wof:country":"HT",
     "wof:created":1469052496,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"11d7a9815ed757e8c302252491dc88b0",
     "wof:hierarchy":[
         {
@@ -275,7 +278,7 @@
         }
     ],
     "wof:id":890445093,
-    "wof:lastmodified":1566648905,
+    "wof:lastmodified":1582318455,
     "wof:name":"Hinche",
     "wof:parent_id":1091686313,
     "wof:placetype":"locality",

--- a/data/890/445/109/890445109.geojson
+++ b/data/890/445/109/890445109.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"HT",
     "wof:created":1469052497,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e851f98a8bf8a72c7fa8a6bb10bf6fa6",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":890445109,
-    "wof:lastmodified":1566648905,
+    "wof:lastmodified":1582318455,
     "wof:name":"Ti Port-de-Paix",
     "wof:parent_id":1091686781,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.