### PR TITLE
Name updates

### DIFF
--- a/data/856/324/33/85632433.geojson
+++ b/data/856/324/33/85632433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.328067,
-    "geom:area_square_m":27227808936.638199,
+    "geom:area_square_m":27227809547.380165,
     "geom:bbox":"-74.482941,18.020416,-71.62181,20.088388",
     "geom:latitude":18.936379,
     "geom:longitude":-72.688703,
@@ -43,6 +43,9 @@
     "name:amh_x_variant":[
         "\u1200\u12ed\u1272"
     ],
+    "name:ang_x_preferred":[
+        "Hait\u012beg"
+    ],
     "name:ara_x_preferred":[
         "\u0647\u0627\u064a\u062a\u064a"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:arg_x_preferred":[
         "Hait\u00ed"
+    ],
+    "name:ary_x_preferred":[
+        "\u0647\u0627\u064a\u062a\u064a"
     ],
     "name:arz_x_preferred":[
         "\u0647\u0627\u064a\u064a\u062a\u0649"
@@ -160,6 +166,12 @@
     "name:dan_x_preferred":[
         "Haiti"
     ],
+    "name:deu_at_x_preferred":[
+        "Haiti"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Haiti"
+    ],
     "name:deu_x_preferred":[
         "Haiti"
     ],
@@ -177,6 +189,12 @@
     ],
     "name:ell_x_preferred":[
         "\u0391\u03ca\u03c4\u03ae"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Haiti"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Haiti"
     ],
     "name:eng_x_preferred":[
         "Haiti"
@@ -595,6 +613,9 @@
     "name:pol_x_preferred":[
         "Haiti"
     ],
+    "name:por_br_x_preferred":[
+        "Haiti"
+    ],
     "name:por_x_preferred":[
         "Haiti"
     ],
@@ -640,6 +661,9 @@
     "name:san_x_preferred":[
         "\u0939\u0947\u091f\u0940"
     ],
+    "name:sat_x_preferred":[
+        "\u1c66\u1c5f\u1c6d\u1c5b\u1c64"
+    ],
     "name:scn_x_preferred":[
         "Aiti"
     ],
@@ -667,6 +691,9 @@
     "name:sme_x_preferred":[
         "Haiti"
     ],
+    "name:smo_x_preferred":[
+        "Haiti"
+    ],
     "name:sna_x_preferred":[
         "Haiti"
     ],
@@ -688,6 +715,12 @@
     "name:srd_x_preferred":[
         "Haiti"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0425\u0430\u0438\u0442\u0438"
+    ],
+    "name:srp_el_x_preferred":[
+        "Haiti"
+    ],
     "name:srp_x_preferred":[
         "\u0425\u0430\u0438\u0442\u0438"
     ],
@@ -705,6 +738,9 @@
     ],
     "name:szl_x_preferred":[
         "Hajiti"
+    ],
+    "name:szy_x_preferred":[
+        "Haiti"
     ],
     "name:tah_x_preferred":[
         "Ha\u00ecti"
@@ -726,6 +762,9 @@
     ],
     "name:tet_x_preferred":[
         "Hait\u00ed"
+    ],
+    "name:tgk_x_preferred":[
+        "\u04b2\u043e\u0438\u0442\u04e3"
     ],
     "name:tgl_x_preferred":[
         "Hayti"
@@ -751,6 +790,9 @@
     ],
     "name:tur_x_preferred":[
         "Haiti"
+    ],
+    "name:udm_x_preferred":[
+        "\u0413\u0430\u0438\u0442\u0438 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430"
     ],
     "name:uig_x_preferred":[
         "\u06be\u0627\u064a\u062a\u0649"
@@ -986,7 +1028,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1583797350,
+    "wof:lastmodified":1587427687,
     "wof:name":"Haiti",
     "wof:parent_id":102191575,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.