### PR TITLE
Update megacity records

### DIFF
--- a/data/421/176/527/421176527.geojson
+++ b/data/421/176/527/421176527.geojson
@@ -520,6 +520,7 @@
     "wof:concordances":{
         "gn:id":3718426,
         "gp:id":96110,
+        "ne:id":1159150589,
         "qs_pg:id":1046644,
         "wd:id":"Q34261",
         "wk:page":"Port-au-Prince"
@@ -540,7 +541,8 @@
         }
     ],
     "wof:id":421176527,
-    "wof:lastmodified":1607390900,
+    "wof:lastmodified":1608688176,
+    "wof:megacity":1,
     "wof:name":"Port-au-Prince",
     "wof:parent_id":1091686735,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary