### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/577/714/5/1125777145.geojson
+++ b/data/112/577/714/5/1125777145.geojson
@@ -28,6 +28,9 @@
     "name:ceb_x_preferred":[
         "Fond Verrettes"
     ],
+    "name:ell_x_preferred":[
+        "\u03a6\u03bf\u03bd-\u0392\u03b5\u03c1\u03ad\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Fonds-Verrettes"
     ],
@@ -44,6 +47,12 @@
         "Fonv\u00e8r\u00e8t"
     ],
     "name:ita_x_preferred":[
+        "Fonds-Verrettes"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d5\u30a9\u30f3\u30f4\u30a7\u30ec\u30c3\u30c8"
+    ],
+    "name:nan_x_preferred":[
         "Fonds-Verrettes"
     ],
     "name:nld_x_preferred":[
@@ -66,6 +75,9 @@
     ],
     "name:und_x_variant":[
         "Fonds Verettes"
+    ],
+    "name:zho_x_preferred":[
+        "\u51af\u65af-\u7ef4\u96f7\u7279"
     ],
     "qs_pg:aaroncc":"HT",
     "qs_pg:gn_country":"HT",
@@ -106,7 +118,7 @@
         }
     ],
     "wof:id":1125777145,
-    "wof:lastmodified":1566648907,
+    "wof:lastmodified":1690930620,
     "wof:name":"Fond Verrettes",
     "wof:parent_id":1091687379,
     "wof:placetype":"locality",

--- a/data/112/578/145/3/1125781453.geojson
+++ b/data/112/578/145/3/1125781453.geojson
@@ -25,11 +25,20 @@
     "name:ara_x_preferred":[
         "\u063a\u0648\u0646\u0627\u064a\u064a\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u0646\u0627\u064a\u064a\u0641"
+    ],
+    "name:ast_x_preferred":[
+        "Gona\u00efves"
+    ],
     "name:aze_x_preferred":[
         "Qonaiv"
     ],
     "name:ben_x_preferred":[
         "\u0997\u09c1\u09a8\u09be\u0987\u09ad\u09c7\u09b8"
+    ],
+    "name:cat_x_preferred":[
+        "Gona\u00efves"
     ],
     "name:ceb_x_preferred":[
         "Gonayiv"
@@ -42,6 +51,9 @@
     ],
     "name:ell_x_preferred":[
         "\u0393\u03ba\u03bf\u03bd\u03b1\u0390\u03b2\u03b5\u03c2"
+    ],
+    "name:ell_x_variant":[
+        "\u039b\u03b5 \u0393\u03ba\u03bf\u03bd\u03b1\u0390\u03b2"
     ],
     "name:eng_x_preferred":[
         "Gona\u00efves"
@@ -58,6 +70,12 @@
     "name:fra_x_preferred":[
         "Les Gona\u00efves"
     ],
+    "name:frr_x_preferred":[
+        "Gona\u00efves"
+    ],
+    "name:gle_x_preferred":[
+        "Gona\u00efves"
+    ],
     "name:guj_x_preferred":[
         "\u0a97\u0acb\u0aa8\u0acb\u0a87\u0ab5\u0acd\u0ab8"
     ],
@@ -69,6 +87,9 @@
     ],
     "name:hin_x_preferred":[
         "\u0932\u0947 \u0917\u0941\u0928\u093e\u0908\u0935"
+    ],
+    "name:ile_x_preferred":[
+        "Gona\u00efves"
     ],
     "name:ind_x_preferred":[
         "Gona\u00efves"
@@ -95,6 +116,12 @@
         "\u0917\u0949\u0928\u0935\u094d\u0939\u0940\u090f\u0938"
     ],
     "name:msa_x_preferred":[
+        "Gonaives"
+    ],
+    "name:nan_x_preferred":[
+        "Gona\u00efves"
+    ],
+    "name:nau_x_preferred":[
         "Gonaives"
     ],
     "name:nld_x_preferred":[
@@ -133,6 +160,9 @@
     "name:swe_x_preferred":[
         "Gonayiv"
     ],
+    "name:szl_x_preferred":[
+        "Gona\u00efves"
+    ],
     "name:tam_x_preferred":[
         "\u0b95\u0bcb\u0ba3\u0bc8\u0bb5\u0bc7\u0bb8\u0bcd"
     ],
@@ -154,11 +184,17 @@
     "name:urd_x_preferred":[
         "\u06af\u0648\u0646\u0627\u06cc\u0626\u0648"
     ],
+    "name:vec_x_preferred":[
+        "Les Gona\u00efves"
+    ],
     "name:vie_x_preferred":[
         "Gonaives"
     ],
     "name:war_x_preferred":[
         "Gonaives"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d2\u10dd\u10dc\u10d0\u10d8\u10d5\u10d8"
     ],
     "name:zho_x_preferred":[
         "\u6208\u7eb3\u4f0a\u592b"
@@ -202,7 +238,7 @@
         }
     ],
     "wof:id":1125781453,
-    "wof:lastmodified":1566648907,
+    "wof:lastmodified":1690930619,
     "wof:name":"Gona\u00efves",
     "wof:parent_id":1091687025,
     "wof:placetype":"locality",

--- a/data/112/587/437/3/1125874373.geojson
+++ b/data/112/587/437/3/1125874373.geojson
@@ -25,6 +25,15 @@
     "name:ara_x_preferred":[
         "\u062f\u064a\u0645 \u0645\u0627\u0631\u064a"
     ],
+    "name:cat_x_preferred":[
+        "Dame Marie"
+    ],
+    "name:ceb_x_preferred":[
+        "Dame Marie"
+    ],
+    "name:ell_x_preferred":[
+        "\u039d\u03c4\u03b1\u03bc-\u039c\u03b1\u03c1\u03af"
+    ],
     "name:eng_x_preferred":[
         "Dame-Marie"
     ],
@@ -40,6 +49,9 @@
     "name:jpn_x_preferred":[
         "\u30c0\u30e0\u30fb\u30de\u30ea\u30fc"
     ],
+    "name:nan_x_preferred":[
+        "Dame-Marie"
+    ],
     "name:nld_x_preferred":[
         "Dame-Marie"
     ],
@@ -51,6 +63,9 @@
     ],
     "name:spa_x_preferred":[
         "Dame-Marie"
+    ],
+    "name:swe_x_preferred":[
+        "Dame Marie"
     ],
     "name:und_x_variant":[
         "Ville de Dame Marie"
@@ -94,7 +109,7 @@
         }
     ],
     "wof:id":1125874373,
-    "wof:lastmodified":1566648907,
+    "wof:lastmodified":1690930619,
     "wof:name":"Dame-Marie",
     "wof:parent_id":1091686011,
     "wof:placetype":"locality",

--- a/data/112/589/499/5/1125894995.geojson
+++ b/data/112/589/499/5/1125894995.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Phaeton"
+    ],
     "name:eng_x_preferred":[
         "Phaeton"
     ],
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":1125894995,
-    "wof:lastmodified":1566648906,
+    "wof:lastmodified":1690930619,
     "wof:name":"Pha\u00e9ton",
     "wof:parent_id":1091687099,
     "wof:placetype":"locality",

--- a/data/112/594/094/3/1125940943.geojson
+++ b/data/112/594/094/3/1125940943.geojson
@@ -28,6 +28,9 @@
     "name:ceb_x_preferred":[
         "Thomonde"
     ],
+    "name:ell_x_preferred":[
+        "\u03a4\u03bf\u03bc\u03cc\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Thomonde"
     ],
@@ -40,10 +43,19 @@
     "name:hat_x_variant":[
         "Tomonn"
     ],
+    "name:heb_x_preferred":[
+        "\u05ea\u05d5\u05de\u05d5\u05e0\u05d3"
+    ],
     "name:ita_x_preferred":[
         "Thomonde"
     ],
+    "name:nan_x_preferred":[
+        "Thomonde"
+    ],
     "name:nld_x_preferred":[
+        "Thomonde"
+    ],
+    "name:pol_x_preferred":[
         "Thomonde"
     ],
     "name:por_x_preferred":[
@@ -51,6 +63,9 @@
     ],
     "name:ron_x_preferred":[
         "Thomonde"
+    ],
+    "name:rus_x_preferred":[
+        "\u0422\u043e\u043c\u043e\u043d\u0434"
     ],
     "name:spa_x_preferred":[
         "Thomonde"
@@ -97,7 +112,7 @@
         }
     ],
     "wof:id":1125940943,
-    "wof:lastmodified":1566648906,
+    "wof:lastmodified":1690930618,
     "wof:name":"Thomonde",
     "wof:parent_id":1091686313,
     "wof:placetype":"locality",

--- a/data/112/594/096/1/1125940961.geojson
+++ b/data/112/594/096/1/1125940961.geojson
@@ -28,6 +28,12 @@
     "name:ceb_x_preferred":[
         "Thomazeau"
     ],
+    "name:deu_x_preferred":[
+        "Thomazeau"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a4\u03bf\u03bc\u03b1\u03b6\u03ce"
+    ],
     "name:eng_x_preferred":[
         "Thomazeau"
     ],
@@ -38,6 +44,12 @@
         "Tomazo"
     ],
     "name:ita_x_preferred":[
+        "Thomazeau"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30c8\u30de\u30be\u30fc"
+    ],
+    "name:nan_x_preferred":[
         "Thomazeau"
     ],
     "name:nld_x_preferred":[
@@ -51,6 +63,9 @@
     ],
     "name:ron_x_preferred":[
         "Thomazeau"
+    ],
+    "name:rus_x_preferred":[
+        "\u0422\u043e\u043c\u0430\u0437\u043e"
     ],
     "name:spa_x_preferred":[
         "Thomazeau"
@@ -100,7 +115,7 @@
         }
     ],
     "wof:id":1125940961,
-    "wof:lastmodified":1566648906,
+    "wof:lastmodified":1690930618,
     "wof:name":"Thomazeau",
     "wof:parent_id":1091687379,
     "wof:placetype":"locality",

--- a/data/112/594/097/1/1125940971.geojson
+++ b/data/112/594/097/1/1125940971.geojson
@@ -31,6 +31,12 @@
     "name:ceb_x_preferred":[
         "Thiote"
     ],
+    "name:ceb_x_variant":[
+        "Thiotte"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a4\u03b9\u03cc\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Thiotte"
     ],
@@ -41,6 +47,12 @@
         "Ty\u00f2t"
     ],
     "name:ita_x_preferred":[
+        "Thiotte"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30c1\u30e7\u30c3\u30c8"
+    ],
+    "name:nan_x_preferred":[
         "Thiotte"
     ],
     "name:nld_x_preferred":[
@@ -57,6 +69,9 @@
     ],
     "name:swe_x_preferred":[
         "Thiote"
+    ],
+    "name:swe_x_variant":[
+        "Thiotte"
     ],
     "name:und_x_variant":[
         "Ca\u00ef-Tiot"
@@ -100,7 +115,7 @@
         }
     ],
     "wof:id":1125940971,
-    "wof:lastmodified":1566648906,
+    "wof:lastmodified":1690930618,
     "wof:name":"Thiote",
     "wof:parent_id":1091686107,
     "wof:placetype":"locality",

--- a/data/112/601/650/3/1126016503.geojson
+++ b/data/112/601/650/3/1126016503.geojson
@@ -25,8 +25,14 @@
     "name:ara_x_preferred":[
         "\u0623\u0643\u0648\u064a\u0646"
     ],
+    "name:ceb_x_preferred":[
+        "Aquin"
+    ],
     "name:deu_x_preferred":[
         "Aquin"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03ba\u03ad\u03bd"
     ],
     "name:eng_x_preferred":[
         "Aquin"
@@ -40,6 +46,12 @@
     "name:ita_x_preferred":[
         "Aquin"
     ],
+    "name:jpn_x_preferred":[
+        "\u30a2\u30ab\u30f3"
+    ],
+    "name:nan_x_preferred":[
+        "Aquin"
+    ],
     "name:nld_x_preferred":[
         "Aquin"
     ],
@@ -50,6 +62,9 @@
         "Aquin"
     ],
     "name:spa_x_preferred":[
+        "Aquin"
+    ],
+    "name:swe_x_preferred":[
         "Aquin"
     ],
     "qs_pg:aaroncc":"HT",
@@ -91,7 +106,7 @@
         }
     ],
     "wof:id":1126016503,
-    "wof:lastmodified":1566648907,
+    "wof:lastmodified":1690930619,
     "wof:name":"Aquin",
     "wof:parent_id":1091687293,
     "wof:placetype":"locality",

--- a/data/112/601/650/9/1126016509.geojson
+++ b/data/112/601/650/9/1126016509.geojson
@@ -25,8 +25,20 @@
     "name:ara_x_preferred":[
         "\u0622\u0646\u0633 \u0641\u064a\u0648\u064a"
     ],
+    "name:cat_x_preferred":[
+        "Anse-\u00e0-Veau"
+    ],
     "name:ceb_x_preferred":[
         "Anse-\u00e0-Veau"
+    ],
+    "name:ceb_x_variant":[
+        "Ansavo"
+    ],
+    "name:deu_x_preferred":[
+        "Anse-\u00e0-Veau"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03bd\u03c2-\u03b1-\u0392\u03c9"
     ],
     "name:eng_x_preferred":[
         "Anse-\u00e0-Veau"
@@ -38,6 +50,9 @@
         "Ansavo"
     ],
     "name:ita_x_preferred":[
+        "Anse-\u00e0-Veau"
+    ],
+    "name:nan_x_preferred":[
         "Anse-\u00e0-Veau"
     ],
     "name:nld_x_preferred":[
@@ -52,14 +67,23 @@
     "name:rus_x_preferred":[
         "\u0410\u043d\u0441-\u0430-\u0412\u0443"
     ],
+    "name:rus_x_variant":[
+        "\u0410\u043d\u0441-\u0430-\u0412\u043e"
+    ],
     "name:spa_x_preferred":[
         "Anse-\u00e0-Veau"
     ],
     "name:swe_x_preferred":[
         "Anse-\u00e0-Veau"
     ],
+    "name:swe_x_variant":[
+        "Ansavo"
+    ],
     "name:ukr_x_preferred":[
         "\u0410\u043d\u0441-\u0430-\u0412\u0443"
+    ],
+    "name:ukr_x_variant":[
+        "\u0410\u043d\u0441-\u0430-\u0412\u043e"
     ],
     "name:und_x_variant":[
         "Ville de Anse \u00e0 Veau"
@@ -106,7 +130,7 @@
         }
     ],
     "wof:id":1126016509,
-    "wof:lastmodified":1566648907,
+    "wof:lastmodified":1690930619,
     "wof:name":"Anse-\u00e0-Veau",
     "wof:parent_id":1091687241,
     "wof:placetype":"locality",

--- a/data/114/190/696/7/1141906967.geojson
+++ b/data/114/190/696/7/1141906967.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-72.6832485369,19.4504264516,-72.6832485369,19.4504264516",
+    "geom:bbox":"-72.683249,19.450426,-72.683249,19.450426",
     "geom:latitude":19.450426,
     "geom:longitude":-72.683249,
     "iso:country":"HT",
@@ -21,11 +21,20 @@
     "name:ara_x_preferred":[
         "\u063a\u0648\u0646\u0627\u064a\u064a\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u0646\u0627\u064a\u064a\u0641"
+    ],
+    "name:ast_x_preferred":[
+        "Gona\u00efves"
+    ],
     "name:aze_x_preferred":[
         "Qonaiv"
     ],
     "name:ben_x_preferred":[
         "\u0997\u09c1\u09a8\u09be\u0987\u09ad\u09c7\u09b8"
+    ],
+    "name:cat_x_preferred":[
+        "Gona\u00efves"
     ],
     "name:ceb_x_preferred":[
         "Gonayiv"
@@ -38,6 +47,9 @@
     ],
     "name:ell_x_preferred":[
         "\u0393\u03ba\u03bf\u03bd\u03b1\u0390\u03b2\u03b5\u03c2"
+    ],
+    "name:ell_x_variant":[
+        "\u039b\u03b5 \u0393\u03ba\u03bf\u03bd\u03b1\u0390\u03b2"
     ],
     "name:eng_x_preferred":[
         "Gona\u00efves"
@@ -54,6 +66,12 @@
     "name:fra_x_preferred":[
         "Les Gona\u00efves"
     ],
+    "name:frr_x_preferred":[
+        "Gona\u00efves"
+    ],
+    "name:gle_x_preferred":[
+        "Gona\u00efves"
+    ],
     "name:guj_x_preferred":[
         "\u0a97\u0acb\u0aa8\u0acb\u0a87\u0ab5\u0acd\u0ab8"
     ],
@@ -65,6 +83,9 @@
     ],
     "name:hin_x_preferred":[
         "\u0932\u0947 \u0917\u0941\u0928\u093e\u0908\u0935"
+    ],
+    "name:ile_x_preferred":[
+        "Gona\u00efves"
     ],
     "name:ind_x_preferred":[
         "Gona\u00efves"
@@ -91,6 +112,12 @@
         "\u0917\u0949\u0928\u0935\u094d\u0939\u0940\u090f\u0938"
     ],
     "name:msa_x_preferred":[
+        "Gonaives"
+    ],
+    "name:nan_x_preferred":[
+        "Gona\u00efves"
+    ],
+    "name:nau_x_preferred":[
         "Gonaives"
     ],
     "name:nld_x_preferred":[
@@ -129,6 +156,9 @@
     "name:swe_x_preferred":[
         "Gonayiv"
     ],
+    "name:szl_x_preferred":[
+        "Gona\u00efves"
+    ],
     "name:tam_x_preferred":[
         "\u0b95\u0bcb\u0ba3\u0bc8\u0bb5\u0bc7\u0bb8\u0bcd"
     ],
@@ -147,11 +177,17 @@
     "name:urd_x_preferred":[
         "\u06af\u0648\u0646\u0627\u06cc\u0626\u0648"
     ],
+    "name:vec_x_preferred":[
+        "Les Gona\u00efves"
+    ],
     "name:vie_x_preferred":[
         "Gonaives"
     ],
     "name:war_x_preferred":[
         "Gonaives"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d2\u10dd\u10dc\u10d0\u10d8\u10d5\u10d8"
     ],
     "name:zho_x_preferred":[
         "\u6208\u7eb3\u4f0a\u592b"
@@ -264,7 +300,7 @@
     },
     "wof:country":"HT",
     "wof:created":1499130662,
-    "wof:geomhash":"873bb2103b93a93f27a30f35d111593c",
+    "wof:geomhash":"0ab9cacc46239b8c7d68e95923916329",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -275,7 +311,7 @@
         }
     ],
     "wof:id":1141906967,
-    "wof:lastmodified":1566649324,
+    "wof:lastmodified":1690930622,
     "wof:name":"Gonaives",
     "wof:parent_id":1091687025,
     "wof:placetype":"locality",
@@ -285,10 +321,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -72.68324853686164,
-    19.45042645159162,
-    -72.68324853686164,
-    19.45042645159162
+    -72.683249,
+    19.450426,
+    -72.683249,
+    19.450426
 ],
-  "geometry": {"coordinates":[-72.68324853686164,19.45042645159162],"type":"Point"}
+  "geometry": {"coordinates":[-72.683249,19.450426],"type":"Point"}
 }

--- a/data/421/168/265/421168265.geojson
+++ b/data/421/168/265/421168265.geojson
@@ -20,11 +20,26 @@
     "name:ara_x_preferred":[
         "\u0628\u064a\u062a\u064a\u0648\u0646\u0641\u064a\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u064a\u062a\u064a\u0648\u0646\u0641\u064a\u0644"
+    ],
+    "name:ast_x_preferred":[
+        "P\u00e9tion-Ville"
+    ],
+    "name:aze_x_preferred":[
+        "Petyonvil"
+    ],
     "name:ben_x_preferred":[
         "\u09aa\u09c7\u09b6\u09a8-\u09ad\u09bf\u09b2\u09bf"
     ],
+    "name:cat_x_preferred":[
+        "P\u00e9tion-Ville"
+    ],
     "name:ceb_x_preferred":[
         "P\u00e9tionville"
+    ],
+    "name:ceb_x_variant":[
+        "Petyon-Vil"
     ],
     "name:dan_x_preferred":[
         "P\u00e9tionville"
@@ -34,6 +49,9 @@
     ],
     "name:ell_x_preferred":[
         "\u03a0\u03ad\u03c4\u03b9\u03bf\u03bd-\u0392\u03af\u03bb\u03bb\u03b5"
+    ],
+    "name:ell_x_variant":[
+        "\u03a0\u03b5\u03c4\u03b9\u03cc\u03bd-\u0392\u03b9\u03bb"
     ],
     "name:eng_x_preferred":[
         "P\u00e9tion-Ville"
@@ -45,6 +63,9 @@
         "P\u00e9tionville"
     ],
     "name:fra_x_variant":[
+        "P\u00e9tion-Ville"
+    ],
+    "name:gle_x_preferred":[
         "P\u00e9tion-Ville"
     ],
     "name:guj_x_preferred":[
@@ -86,6 +107,12 @@
     "name:msa_x_preferred":[
         "Petion-Ville"
     ],
+    "name:nan_x_preferred":[
+        "P\u00e9tion-Ville"
+    ],
+    "name:nau_x_preferred":[
+        "P\u00e9tionville"
+    ],
     "name:nld_x_preferred":[
         "P\u00e9tionville"
     ],
@@ -122,14 +149,26 @@
     "name:swe_x_preferred":[
         "P\u00e9tionville"
     ],
+    "name:swe_x_variant":[
+        "Petyon-Vil"
+    ],
+    "name:szl_x_preferred":[
+        "P\u00e9tion-Ville"
+    ],
     "name:tam_x_preferred":[
         "\u0baa\u0bc6\u0b9f\u0bbf\u0baf\u0ba9\u0bcd -\u0bb5\u0bbf\u0bb2\u0bcd\u0bb2\u0bc7"
     ],
     "name:tel_x_preferred":[
         "\u0c2a\u0c46\u0c1f\u0c3f\u0c2f\u0c3e\u0c28\u0c4d-\u0c35\u0c3f\u0c32\u0c4d\u0c32\u0c47"
     ],
+    "name:tgk_x_preferred":[
+        "\u041f\u0435\u0442\u0438\u043e\u043d\u0432\u0438\u043b"
+    ],
     "name:tha_x_preferred":[
         "\u0e40\u0e1b\u0e0a\u0e34\u0e22\u0e07\u0e27\u0e35\u0e25"
+    ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e1b\u0e15\u0e35\u0e22\u0e07-\u0e27\u0e35\u0e25"
     ],
     "name:tur_x_preferred":[
         "Petion-Ville"
@@ -137,14 +176,23 @@
     "name:ukr_x_preferred":[
         "\u041f\u0435\u0442\u044c\u043e\u043d\u0432\u0456\u043b\u044c"
     ],
+    "name:ukr_x_variant":[
+        "\u041f\u0435\u0442\u044c\u043e\u043d-\u0412\u0456\u043b\u043b\u044c"
+    ],
     "name:und_x_variant":[
         "Ville de P\u00e9tion-Ville"
     ],
     "name:urd_x_preferred":[
         "\u067e\u06cc\u0634\u0646-\u0648\u06cc\u0644\u06cc"
     ],
+    "name:vec_x_preferred":[
+        "P\u00e9tionville"
+    ],
     "name:vie_x_preferred":[
         "Petion-Ville"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10de\u10d4\u10e2\u10d8\u10dd\u10dc\u10d5\u10d8\u10da\u10d8"
     ],
     "name:zho_x_preferred":[
         "\u4f69\u8482\u7fc1\u7dad\u723e"
@@ -200,7 +248,7 @@
         }
     ],
     "wof:id":421168265,
-    "wof:lastmodified":1566648891,
+    "wof:lastmodified":1690930598,
     "wof:name":"P\u00e9tionville",
     "wof:parent_id":1091686735,
     "wof:placetype":"locality",

--- a/data/421/168/267/421168267.geojson
+++ b/data/421/168/267/421168267.geojson
@@ -35,6 +35,9 @@
     "name:ell_x_preferred":[
         "\u039f\u03c5\u03b1\u03bd\u03b1\u03bc\u03af\u03bd\u03c4\u03b5"
     ],
+    "name:ell_x_variant":[
+        "\u039f\u03c5\u03b1\u03bd\u03b1\u03bc\u03ad\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Ouanaminthe"
     ],
@@ -78,6 +81,9 @@
         "\u0913\u090a\u0928\u093e\u092e\u0945\u092e\u0902\u0925\u0947"
     ],
     "name:msa_x_preferred":[
+        "Ouanaminthe"
+    ],
+    "name:nan_x_preferred":[
         "Ouanaminthe"
     ],
     "name:nld_x_preferred":[
@@ -134,6 +140,9 @@
     "name:vie_x_preferred":[
         "Ouanaminthe"
     ],
+    "name:zho_x_preferred":[
+        "\u74e6\u7d0d\u660e\u7279"
+    ],
     "qs:gn_country":"HT",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":3719436,
@@ -182,7 +191,7 @@
         }
     ],
     "wof:id":421168267,
-    "wof:lastmodified":1566648891,
+    "wof:lastmodified":1690930597,
     "wof:name":"Ouanaminthe",
     "wof:parent_id":1091687117,
     "wof:placetype":"locality",

--- a/data/421/168/421/421168421.geojson
+++ b/data/421/168/421/421168421.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Plaisance"
     ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03bb\u03b1\u03b9\u03b6\u03ac\u03bd\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Plaisance"
     ],
@@ -44,7 +47,16 @@
     "name:ita_x_preferred":[
         "Plaisance"
     ],
+    "name:jpn_x_preferred":[
+        "\u30d7\u30ec\u30b6\u30f3\u30b9"
+    ],
+    "name:nan_x_preferred":[
+        "Plaisance"
+    ],
     "name:nld_x_preferred":[
+        "Plaisance"
+    ],
+    "name:pol_x_preferred":[
         "Plaisance"
     ],
     "name:por_x_preferred":[
@@ -105,7 +117,7 @@
         }
     ],
     "wof:id":421168421,
-    "wof:lastmodified":1636495611,
+    "wof:lastmodified":1690930598,
     "wof:name":"Plaisance",
     "wof:parent_id":1091686691,
     "wof:placetype":"locality",

--- a/data/421/169/155/421169155.geojson
+++ b/data/421/169/155/421169155.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0628 \u0647\u0627\u064a\u062a\u064a\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0628 \u0647\u0627\u064a\u062a\u064a\u0627\u0646"
+    ],
     "name:ast_x_preferred":[
         "Cap-Ha\u00eftien"
     ],
@@ -32,8 +35,14 @@
     "name:bul_x_preferred":[
         "\u041a\u0430\u043f \u0410\u0438\u0442\u0438\u0435\u043d"
     ],
+    "name:cat_x_preferred":[
+        "Cap-Ha\u00eftien"
+    ],
     "name:ceb_x_preferred":[
         "Cap Ha\u00eftien"
+    ],
+    "name:ceb_x_variant":[
+        "Okap"
     ],
     "name:ces_x_preferred":[
         "Cap-Ha\u00eftien"
@@ -56,6 +65,9 @@
     "name:ell_x_preferred":[
         "\u039a\u03b1\u03c0-\u0391\u03ca\u03c4\u03b9\u03ad\u03bd"
     ],
+    "name:ell_x_variant":[
+        "\u039a\u03b1\u03c0-\u0391\u03ca\u03c3\u03b9\u03ad\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Cap-Ha\u00eftien"
     ],
@@ -65,6 +77,9 @@
     "name:est_x_preferred":[
         "Cap-Ha\u00eftien"
     ],
+    "name:eus_x_preferred":[
+        "Cap-Ha\u00eftien"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0627\u067e-\u0647\u0627\u0626\u06cc\u062a\u06cc\u0646"
     ],
@@ -72,6 +87,9 @@
         "Cap-Ha\u00eftien"
     ],
     "name:fra_x_preferred":[
+        "Cap-Ha\u00eftien"
+    ],
+    "name:gle_x_preferred":[
         "Cap-Ha\u00eftien"
     ],
     "name:guj_x_preferred":[
@@ -85,6 +103,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05e7\u05d0\u05e4-\u05d4\u05d0\u05d9\u05d8\u05d9\u05d9\u05df"
+    ],
+    "name:heb_x_variant":[
+        "\u05e7\u05d0\u05e4-\u05d4\u05d0\u05d9\u05e1\u05d9\u05d9\u05df"
     ],
     "name:hin_x_preferred":[
         "\u0915\u0948\u092a-\u0939\u0948\u0924\u093f\u092f\u0947\u0928"
@@ -128,6 +149,12 @@
     "name:msa_x_preferred":[
         "Cape Haitian"
     ],
+    "name:nan_x_preferred":[
+        "Cap-Ha\u00eftien"
+    ],
+    "name:nau_x_preferred":[
+        "Cap-Haitien"
+    ],
     "name:nld_x_preferred":[
         "Cap-Ha\u00eftien"
     ],
@@ -164,6 +191,9 @@
     "name:swe_x_preferred":[
         "Cap-Ha\u00eftien"
     ],
+    "name:swe_x_variant":[
+        "Okap"
+    ],
     "name:szl_x_preferred":[
         "Cap-Ha\u00eftien"
     ],
@@ -191,11 +221,20 @@
     "name:urd_x_preferred":[
         "\u06a9\u06cc\u067e \u06c1\u06cc\u0679\u06cc\u0627\u0646"
     ],
+    "name:uzb_x_preferred":[
+        "Kap-aityen"
+    ],
+    "name:vec_x_preferred":[
+        "Cap-Ha\u00eftien"
+    ],
     "name:vie_x_preferred":[
         "Cap-Haitien"
     ],
     "name:war_x_preferred":[
         "Cap-Ha\u00eftien"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d9\u10d0\u10de-\u10d0\u10d8\u10e2\u10d4\u10dc\u10d8"
     ],
     "name:zho_x_preferred":[
         "\u6d77\u5730\u89d2"
@@ -344,7 +383,7 @@
         }
     ],
     "wof:id":421169155,
-    "wof:lastmodified":1566648893,
+    "wof:lastmodified":1690930600,
     "wof:name":"Cap-Ha\u00eftien",
     "wof:parent_id":1091686431,
     "wof:placetype":"locality",

--- a/data/421/173/331/421173331.geojson
+++ b/data/421/173/331/421173331.geojson
@@ -20,6 +20,15 @@
     "name:ara_x_preferred":[
         "\u0622\u0643\u0644 \u062f\u0648 \u0646\u0648\u0631\u062f"
     ],
+    "name:cat_x_preferred":[
+        "Acul du Nord"
+    ],
+    "name:ceb_x_preferred":[
+        "Acul du Nord"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03ba\u03cd-\u03bd\u03c4\u03c5-\u039d\u03bf\u03c1"
+    ],
     "name:eng_x_preferred":[
         "Acul-du-Nord"
     ],
@@ -33,13 +42,17 @@
         "Akil din\u00f2"
     ],
     "name:hat_x_variant":[
-        "Akil di N\u00f2"
+        "Akil di N\u00f2",
+        "Akil Din\u00f2"
     ],
     "name:ita_x_preferred":[
         "Acul-du-Nord"
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30ad\u30eb\u30fb\u30c7\u30a3\u30ce\u30fc"
+    ],
+    "name:nan_x_preferred":[
+        "Acul-du-Nord"
     ],
     "name:nld_x_preferred":[
         "Acul-du-Nord"
@@ -53,8 +66,14 @@
     "name:spa_x_preferred":[
         "Acul-du-Nord"
     ],
+    "name:swe_x_preferred":[
+        "Acul du Nord"
+    ],
     "name:ukr_x_preferred":[
         "\u0410\u043a\u0443\u043b-\u0434\u0443-\u041d\u043e\u0440\u0434"
+    ],
+    "name:ukr_x_variant":[
+        "\u0410\u043a\u0443\u043b-\u0434\u044e-\u041d\u043e\u0440"
     ],
     "qs:gn_country":"HT",
     "qs:gn_fcode":"PPL",
@@ -103,7 +122,7 @@
         }
     ],
     "wof:id":421173331,
-    "wof:lastmodified":1566648894,
+    "wof:lastmodified":1690930601,
     "wof:name":"Acul du Nord",
     "wof:parent_id":1091686325,
     "wof:placetype":"locality",

--- a/data/421/173/691/421173691.geojson
+++ b/data/421/173/691/421173691.geojson
@@ -23,6 +23,9 @@
     "name:bre_x_preferred":[
         "Grande-Rivi\u00e8re-du-Nord"
     ],
+    "name:ceb_x_preferred":[
+        "Grande Rivi\u00e8re du Nord"
+    ],
     "name:cos_x_preferred":[
         "Grande-Rivi\u00e8re-du-Nord"
     ],
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421173691,
-    "wof:lastmodified":1566648894,
+    "wof:lastmodified":1690930601,
     "wof:name":"Grande Rivi\u00e8re du Nord",
     "wof:parent_id":1091686273,
     "wof:placetype":"locality",

--- a/data/421/175/093/421175093.geojson
+++ b/data/421/175/093/421175093.geojson
@@ -26,6 +26,9 @@
     "name:deu_x_preferred":[
         "Lascahobas"
     ],
+    "name:ell_x_preferred":[
+        "\u039b\u03b1\u03c3\u03ba\u03b1\u03bf\u03bc\u03c0\u03ac"
+    ],
     "name:eng_x_preferred":[
         "Lascahobas"
     ],
@@ -36,6 +39,9 @@
         "Laskawobas"
     ],
     "name:ita_x_preferred":[
+        "Lascahobas"
+    ],
+    "name:nan_x_preferred":[
         "Lascahobas"
     ],
     "name:nld_x_preferred":[
@@ -112,7 +118,7 @@
         }
     ],
     "wof:id":421175093,
-    "wof:lastmodified":1566648895,
+    "wof:lastmodified":1690930602,
     "wof:name":"Lascahobas",
     "wof:parent_id":1091686393,
     "wof:placetype":"locality",

--- a/data/421/176/525/421176525.geojson
+++ b/data/421/176/525/421176525.geojson
@@ -20,6 +20,9 @@
     "name:ceb_x_preferred":[
         "Tiburon"
     ],
+    "name:ell_x_preferred":[
+        "\u03a4\u03b9\u03bc\u03c0\u03c5\u03c1\u03cc\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Tiburon"
     ],
@@ -30,6 +33,12 @@
         "Tibiwon"
     ],
     "name:ita_x_preferred":[
+        "Tiburon"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30c1\u30d3\u30a6\u30a9\u30f3"
+    ],
+    "name:nan_x_preferred":[
         "Tiburon"
     ],
     "name:nld_x_preferred":[
@@ -95,7 +104,7 @@
         }
     ],
     "wof:id":421176525,
-    "wof:lastmodified":1566648900,
+    "wof:lastmodified":1690930609,
     "wof:name":"Tiburon",
     "wof:parent_id":1091686503,
     "wof:placetype":"locality",

--- a/data/421/176/527/421176527.geojson
+++ b/data/421/176/527/421176527.geojson
@@ -28,8 +28,14 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0631\u062a \u0623\u0648 \u0628\u0631\u0627\u0646\u0633"
     ],
+    "name:arg_x_preferred":[
+        "Port-au-Prince"
+    ],
     "name:ast_x_preferred":[
         "Puertu Pr\u00edncipe"
+    ],
+    "name:avk_x_preferred":[
+        "Port-au-Prince"
     ],
     "name:aym_x_preferred":[
         "Port-au-Prince"
@@ -40,6 +46,9 @@
     "name:aze_x_preferred":[
         "Port-o-Prins"
     ],
+    "name:ban_x_preferred":[
+        "Port-au-Prince"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u043e\u0440\u0442-\u043e-\u041f\u0440\u044d\u043d\u0441"
     ],
@@ -48,6 +57,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09aa\u09cb\u09b0\u09cd\u099f-\u0985-\u09aa\u09cd\u09b0\u09bf\u09a8\u09cd\u09b8"
+    ],
+    "name:ben_x_variant":[
+        "\u09aa\u09b0\u09cd\u09a4\u09cb\u09aa\u09cd\u09b0\u09be\u0981\u09b8"
     ],
     "name:bod_x_preferred":[
         "\u0f54\u0f7c\u0f0b\u0f62\u0f7c\u0f0b\u0f4a\u0f72\u0f0b\u0f68\u0f60\u0f74\u0f0b\u0f54\u0f72\u0f0b\u0f62\u0f72\u0f53\u0f0b\u0f66\u0f72\u0f0d"
@@ -88,6 +100,9 @@
     "name:ell_x_preferred":[
         "\u03a0\u03bf\u03c1\u03c4-\u03bf-\u03a0\u03c1\u03b5\u03bd\u03c2"
     ],
+    "name:ell_x_variant":[
+        "\u03a0\u03bf\u03c1-\u03c9-\u03a0\u03c1\u03b5\u03bd\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Port-au-Prince"
     ],
@@ -107,6 +122,9 @@
         "Port-au-Prince"
     ],
     "name:fra_x_preferred":[
+        "Port-au-Prince"
+    ],
+    "name:frr_x_preferred":[
         "Port-au-Prince"
     ],
     "name:fry_x_preferred":[
@@ -198,6 +216,9 @@
     ],
     "name:lav_x_preferred":[
         "Portoprensa"
+    ],
+    "name:lim_x_preferred":[
+        "Port-au-Prince"
     ],
     "name:lin_x_preferred":[
         "Port-au-Prince"
@@ -307,6 +328,15 @@
     "name:slv_x_preferred":[
         "Port-au-Prince"
     ],
+    "name:sme_x_preferred":[
+        "Port-au-Prince"
+    ],
+    "name:smn_x_preferred":[
+        "Port-au-Prince"
+    ],
+    "name:sms_x_preferred":[
+        "Port-au-Prince"
+    ],
     "name:sna_x_preferred":[
         "Port-au-Prince"
     ],
@@ -352,6 +382,9 @@
     "name:tur_x_preferred":[
         "Port-au-Prince"
     ],
+    "name:udm_x_preferred":[
+        "\u041f\u043e\u0440\u0442-\u043e-\u041f\u0440\u0435\u043d\u0441"
+    ],
     "name:ukr_x_preferred":[
         "\u041f\u043e\u0440\u0442-\u043e-\u041f\u0440\u0435\u043d\u0441"
     ],
@@ -363,6 +396,9 @@
     ],
     "name:uzb_x_preferred":[
         "Port-o-Prens"
+    ],
+    "name:vec_x_preferred":[
+        "Port-au-Prince"
     ],
     "name:vep_x_preferred":[
         "Port-o-Prens"
@@ -510,8 +546,8 @@
     "wof:belongsto":[
         102191575,
         85632433,
-        1091686735,
-        85671967
+        85671967,
+        1091686735
     ],
     "wof:breaches":[],
     "wof:capital_of":[
@@ -541,7 +577,7 @@
         }
     ],
     "wof:id":421176527,
-    "wof:lastmodified":1608688176,
+    "wof:lastmodified":1690930609,
     "wof:megacity":1,
     "wof:name":"Port-au-Prince",
     "wof:parent_id":1091686735,

--- a/data/421/176/529/421176529.geojson
+++ b/data/421/176/529/421176529.geojson
@@ -23,6 +23,12 @@
     "name:ceb_x_preferred":[
         "Chardonni\u00e8re"
     ],
+    "name:ceb_x_variant":[
+        "Chardonni\u00e8res"
+    ],
+    "name:ell_x_preferred":[
+        "\u039b\u03b5 \u03a3\u03b1\u03c1\u03bd\u03c4\u03bf\u03bd\u03b9\u03ad\u03c1"
+    ],
     "name:eng_x_preferred":[
         "Chardonni\u00e8res"
     ],
@@ -38,6 +44,9 @@
     "name:jpn_x_preferred":[
         "\u30b7\u30e3\u30c9\u30cb\u30a8"
     ],
+    "name:nan_x_preferred":[
+        "Chardonni\u00e8res"
+    ],
     "name:nld_x_preferred":[
         "Chardonni\u00e8res"
     ],
@@ -52,6 +61,9 @@
     ],
     "name:swe_x_preferred":[
         "Chardonni\u00e8re"
+    ],
+    "name:swe_x_variant":[
+        "Chardonni\u00e8res"
     ],
     "name:und_x_variant":[
         "Ville de Chardonni\u00e8re"
@@ -104,7 +116,7 @@
         }
     ],
     "wof:id":421176529,
-    "wof:lastmodified":1566648900,
+    "wof:lastmodified":1690930609,
     "wof:name":"Chardonni\u00e8re",
     "wof:parent_id":1091686503,
     "wof:placetype":"locality",

--- a/data/421/176/531/421176531.geojson
+++ b/data/421/176/531/421176531.geojson
@@ -26,6 +26,9 @@
     "name:deu_x_preferred":[
         "Chantal"
     ],
+    "name:ell_x_preferred":[
+        "\u03a3\u03b1\u03bd\u03c4\u03ac\u03bb"
+    ],
     "name:eng_x_preferred":[
         "Chantal"
     ],
@@ -36,6 +39,12 @@
         "Chantal"
     ],
     "name:ita_x_preferred":[
+        "Chantal"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b7\u30e3\u30f3\u30bf\u30eb"
+    ],
+    "name:nan_x_preferred":[
         "Chantal"
     ],
     "name:nld_x_preferred":[
@@ -104,7 +113,7 @@
         }
     ],
     "wof:id":421176531,
-    "wof:lastmodified":1566648900,
+    "wof:lastmodified":1690930609,
     "wof:name":"Chantal",
     "wof:parent_id":1091686479,
     "wof:placetype":"locality",

--- a/data/421/177/501/421177501.geojson
+++ b/data/421/177/501/421177501.geojson
@@ -23,8 +23,17 @@
     "name:fra_x_preferred":[
         "P\u00e8lerin"
     ],
+    "name:fra_x_variant":[
+        "Le P\u00e8lerin"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0410\u045f\u0438\u0458\u0430\u0442\u0430"
+    ],
     "name:nld_x_preferred":[
         "Le P\u00e8lerin"
+    ],
+    "name:zho_x_preferred":[
+        "\u671d\u8056\u8005"
     ],
     "qs:gn_country":"HT",
     "qs:gn_fcode":"PPL",
@@ -72,7 +81,7 @@
         }
     ],
     "wof:id":421177501,
-    "wof:lastmodified":1566648898,
+    "wof:lastmodified":1690930607,
     "wof:name":"P\u00e9lerin",
     "wof:parent_id":1091686735,
     "wof:placetype":"locality",

--- a/data/421/177/559/421177559.geojson
+++ b/data/421/177/559/421177559.geojson
@@ -47,6 +47,9 @@
     "name:ces_x_preferred":[
         "Cornillon"
     ],
+    "name:che_x_preferred":[
+        "\u041a\u043e\u0433\u04c0\u043d\u0438\u0439\u043e\u043d"
+    ],
     "name:cos_x_preferred":[
         "Cornillon"
     ],
@@ -104,6 +107,9 @@
     "name:hat_x_preferred":[
         "K\u00f2niyon"
     ],
+    "name:hat_x_variant":[
+        "koniyon"
+    ],
     "name:hrv_x_preferred":[
         "Cornillon"
     ],
@@ -156,6 +162,9 @@
         "Cornillon"
     ],
     "name:lit_x_preferred":[
+        "Cornillon"
+    ],
+    "name:lld_x_preferred":[
         "Cornillon"
     ],
     "name:lmo_x_preferred":[
@@ -281,8 +290,14 @@
     "name:wol_x_preferred":[
         "Cornillon"
     ],
+    "name:yue_x_preferred":[
+        "Cornillon"
+    ],
     "name:zho_x_preferred":[
         "\u79d1\u5c14\u5c3c\u9686"
+    ],
+    "name:zho_x_variant":[
+        "\u79d1\u5c14\u5c3c\u6c38"
     ],
     "name:zul_x_preferred":[
         "Cornillon"
@@ -334,7 +349,7 @@
         }
     ],
     "wof:id":421177559,
-    "wof:lastmodified":1566648898,
+    "wof:lastmodified":1690930606,
     "wof:name":"Cornillon",
     "wof:parent_id":1091687379,
     "wof:placetype":"locality",

--- a/data/421/177/561/421177561.geojson
+++ b/data/421/177/561/421177561.geojson
@@ -23,6 +23,12 @@
     "name:ceb_x_preferred":[
         "Cerca la Source"
     ],
+    "name:ceb_x_variant":[
+        "Cerca La Source"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a3\u03b5\u03c1\u03ba\u03ac-\u03bb\u03b1-\u03a3\u03bf\u03c5\u03c1\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Cerca-la-Source"
     ],
@@ -33,6 +39,9 @@
         "S\u00e8ka Lasous"
     ],
     "name:ita_x_preferred":[
+        "Cerca-la-Source"
+    ],
+    "name:nan_x_preferred":[
         "Cerca-la-Source"
     ],
     "name:nld_x_preferred":[
@@ -52,6 +61,9 @@
     ],
     "name:swe_x_preferred":[
         "Cerca la Source"
+    ],
+    "name:swe_x_variant":[
+        "Cerca La Source"
     ],
     "name:und_x_variant":[
         "La Source"
@@ -104,7 +116,7 @@
         }
     ],
     "wof:id":421177561,
-    "wof:lastmodified":1566648898,
+    "wof:lastmodified":1690930606,
     "wof:name":"Cerca la Source",
     "wof:parent_id":1091687123,
     "wof:placetype":"locality",

--- a/data/421/178/115/421178115.geojson
+++ b/data/421/178/115/421178115.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0631\u0641\u0648\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0627\u0631\u0641\u0648\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Carrefour"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09cd\u09af\u09be\u09b0\u09bf\u09bf\u09ab\u09cb\u09b0"
     ],
@@ -41,10 +47,19 @@
     "name:epo_x_preferred":[
         "Carrefour"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0627\u0642\u0641\u0648\u0642"
+    ],
     "name:fin_x_preferred":[
         "Carrefour"
     ],
     "name:fra_x_preferred":[
+        "Carrefour"
+    ],
+    "name:frr_x_preferred":[
+        "Carrefour"
+    ],
+    "name:gle_x_preferred":[
         "Carrefour"
     ],
     "name:guj_x_preferred":[
@@ -83,6 +98,9 @@
     "name:msa_x_preferred":[
         "Carrefour"
     ],
+    "name:nan_x_preferred":[
+        "Carrefour"
+    ],
     "name:nld_x_preferred":[
         "Carrefour"
     ],
@@ -94,6 +112,9 @@
     ],
     "name:nor_x_preferred":[
         "Carrefour"
+    ],
+    "name:oss_x_preferred":[
+        "\u041a\u0430\u0440\u0444\u0443\u0440"
     ],
     "name:pol_x_preferred":[
         "Carrefour"
@@ -134,11 +155,17 @@
     "name:urd_x_preferred":[
         "\u06a9\u0627\u0631\u06cc\u0641\u0648\u0648\u0631"
     ],
+    "name:vec_x_preferred":[
+        "Carrefour"
+    ],
     "name:vie_x_preferred":[
         "Carrefour"
     ],
     "name:war_x_preferred":[
         "Carrefour"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d9\u10d0\u10e0\u10e4\u10e3\u10e0\u10d8"
     ],
     "name:zho_x_preferred":[
         "\u5361\u52d2\u5bcc\u723e"
@@ -195,7 +222,7 @@
         }
     ],
     "wof:id":421178115,
-    "wof:lastmodified":1566648900,
+    "wof:lastmodified":1690930608,
     "wof:name":"Carrefour",
     "wof:parent_id":1091686735,
     "wof:placetype":"locality",

--- a/data/421/179/605/421179605.geojson
+++ b/data/421/179/605/421179605.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Dondon"
     ],
+    "name:ell_x_preferred":[
+        "\u039d\u03c4\u03bf\u03bd\u03c4\u03cc\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Dondon"
     ],
@@ -33,6 +36,9 @@
         "Dondon"
     ],
     "name:ita_x_preferred":[
+        "Dondon"
+    ],
+    "name:nan_x_preferred":[
         "Dondon"
     ],
     "name:nld_x_preferred":[
@@ -98,7 +104,7 @@
         }
     ],
     "wof:id":421179605,
-    "wof:lastmodified":1566648899,
+    "wof:lastmodified":1690930607,
     "wof:name":"Dondon",
     "wof:parent_id":1091686895,
     "wof:placetype":"locality",

--- a/data/421/179/607/421179607.geojson
+++ b/data/421/179/607/421179607.geojson
@@ -26,6 +26,9 @@
     "name:deu_x_preferred":[
         "Dessalines"
     ],
+    "name:ell_x_preferred":[
+        "\u039d\u03c4\u03b5\u03c3\u03b1\u03bb\u03af\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Dessalines"
     ],
@@ -36,6 +39,9 @@
         "Desalin"
     ],
     "name:ita_x_preferred":[
+        "Dessalines"
+    ],
+    "name:nan_x_preferred":[
         "Dessalines"
     ],
     "name:nld_x_preferred":[
@@ -112,7 +118,7 @@
         }
     ],
     "wof:id":421179607,
-    "wof:lastmodified":1566648899,
+    "wof:lastmodified":1690930608,
     "wof:name":"Dessalines",
     "wof:parent_id":1091687127,
     "wof:placetype":"locality",

--- a/data/421/179/611/421179611.geojson
+++ b/data/421/179/611/421179611.geojson
@@ -20,6 +20,15 @@
     "name:ara_x_preferred":[
         "\u0623\u0646\u0633 \u0631\u0648\u062c"
     ],
+    "name:cat_x_preferred":[
+        "Anse Rouge"
+    ],
+    "name:ceb_x_preferred":[
+        "Anse Rouge"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03bd\u03c2-\u03a1\u03bf\u03c5\u03b6"
+    ],
     "name:eng_x_preferred":[
         "Anse-Rouge"
     ],
@@ -38,6 +47,9 @@
     "name:jpn_x_preferred":[
         "\u30a2\u30f3\u30b9\uff1d\u30eb\u30fc\u30b8\u30e5"
     ],
+    "name:nan_x_preferred":[
+        "Anse-Rouge"
+    ],
     "name:nld_x_preferred":[
         "Anse-Rouge"
     ],
@@ -49,6 +61,9 @@
     ],
     "name:spa_x_preferred":[
         "Anse-Rouge"
+    ],
+    "name:swe_x_preferred":[
+        "Anse Rouge"
     ],
     "name:und_x_variant":[
         "Ville de l\u2019Anse Rouge"
@@ -100,7 +115,7 @@
         }
     ],
     "wof:id":421179611,
-    "wof:lastmodified":1566648898,
+    "wof:lastmodified":1690930607,
     "wof:name":"Anse Rouge",
     "wof:parent_id":1091686981,
     "wof:placetype":"locality",

--- a/data/421/179/613/421179613.geojson
+++ b/data/421/179/613/421179613.geojson
@@ -23,6 +23,12 @@
     "name:ceb_x_preferred":[
         "Anse-\u00e0-Pitre"
     ],
+    "name:ceb_x_variant":[
+        "Ansapit"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03bd\u03c2-\u03b1-\u03a0\u03b9\u03c4\u03c1"
+    ],
     "name:eng_x_preferred":[
         "Anse-\u00e0-Pitres"
     ],
@@ -44,6 +50,9 @@
     "name:jpn_x_preferred":[
         "\u30a2\u30f3\u30b5\u30d4\u30c3\u30c8"
     ],
+    "name:nan_x_preferred":[
+        "Anse-\u00e0-Pitres"
+    ],
     "name:nld_x_preferred":[
         "Anse-\u00e0-Pitre"
     ],
@@ -62,8 +71,14 @@
     "name:swe_x_preferred":[
         "Anse-\u00e0-Pitre"
     ],
+    "name:swe_x_variant":[
+        "Ansapit"
+    ],
     "name:ukr_x_preferred":[
         "\u0410\u043d\u0441-\u0430-\u041f\u0456\u0442\u0440"
+    ],
+    "name:zho_x_preferred":[
+        "\u5b89\u585e\u76ae\u7279\u723e"
     ],
     "qs:gn_country":"HT",
     "qs:gn_fcode":"PPL",
@@ -113,7 +128,7 @@
         }
     ],
     "wof:id":421179613,
-    "wof:lastmodified":1566648899,
+    "wof:lastmodified":1690930608,
     "wof:name":"Anse-\u00c0-Pitres",
     "wof:parent_id":1091686107,
     "wof:placetype":"locality",

--- a/data/421/179/617/421179617.geojson
+++ b/data/421/179/617/421179617.geojson
@@ -20,8 +20,17 @@
     "name:ara_x_preferred":[
         "\u0622\u0646\u0633 \u062c\u064a\u0644\u064a\u062a\u0633"
     ],
+    "name:cat_x_preferred":[
+        "Anse a Galets"
+    ],
+    "name:ceb_x_preferred":[
+        "Anse \u00e0 Galets"
+    ],
     "name:deu_x_preferred":[
         "Anse-\u00e0-Galets"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03bd\u03c2-\u03b1-\u0393\u03ba\u03b1\u03bb\u03ad"
     ],
     "name:eng_x_preferred":[
         "Anse-\u00e0-Galets"
@@ -41,7 +50,13 @@
     "name:jpn_x_preferred":[
         "\u30a2\u30f3\u30b9\uff1d\u30a2\uff1d\u30ac\u30ec"
     ],
+    "name:nan_x_preferred":[
+        "Anse-\u00e0-Galets"
+    ],
     "name:nld_x_preferred":[
+        "Anse-\u00e0-Galets"
+    ],
+    "name:pol_x_preferred":[
         "Anse-\u00e0-Galets"
     ],
     "name:por_x_preferred":[
@@ -52,6 +67,9 @@
     ],
     "name:spa_x_preferred":[
         "Anse-\u00e0-Galets"
+    ],
+    "name:swe_x_preferred":[
+        "Anse \u00e0 Galets"
     ],
     "name:und_x_variant":[
         "Anse Galets"
@@ -106,7 +124,7 @@
         }
     ],
     "wof:id":421179617,
-    "wof:lastmodified":1566648898,
+    "wof:lastmodified":1690930607,
     "wof:name":"Anse \u00c0 Galets",
     "wof:parent_id":1091686345,
     "wof:placetype":"locality",

--- a/data/421/179/835/421179835.geojson
+++ b/data/421/179/835/421179835.geojson
@@ -17,13 +17,49 @@
     "mz:is_current":1,
     "mz:min_zoom":6.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:afr_x_preferred":[
+        "Delmas"
+    ],
     "name:ara_x_preferred":[
         "\u062f\u064a\u0644\u0645\u0627\u0633"
+    ],
+    "name:arg_x_preferred":[
+        "Delmas"
+    ],
+    "name:arz_x_preferred":[
+        "\u062f\u064a\u0644\u0645\u0627\u0633"
+    ],
+    "name:ast_x_preferred":[
+        "Delmas"
+    ],
+    "name:bar_x_preferred":[
+        "Delmas"
     ],
     "name:ben_x_preferred":[
         "\u09a1\u09c7\u09b2\u09ae\u09be"
     ],
+    "name:bos_x_preferred":[
+        "Delmas"
+    ],
+    "name:bre_x_preferred":[
+        "Delmas"
+    ],
+    "name:cat_x_preferred":[
+        "Delmas"
+    ],
     "name:ceb_x_preferred":[
+        "Delmas"
+    ],
+    "name:ces_x_preferred":[
+        "Delmas"
+    ],
+    "name:cor_x_preferred":[
+        "Delmas"
+    ],
+    "name:cos_x_preferred":[
+        "Delmas"
+    ],
+    "name:cym_x_preferred":[
         "Delmas"
     ],
     "name:dan_x_preferred":[
@@ -35,16 +71,40 @@
     "name:ell_x_preferred":[
         "\u039d\u03c4\u03ad\u03bb\u03bc\u03b1\u03c2"
     ],
+    "name:ell_x_variant":[
+        "\u039d\u03c4\u03b5\u03bb\u03bc\u03ac\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Delmas"
     ],
     "name:epo_x_preferred":[
         "Delmas"
     ],
+    "name:est_x_preferred":[
+        "Delmas"
+    ],
+    "name:eus_x_preferred":[
+        "Delmas"
+    ],
+    "name:fao_x_preferred":[
+        "Delmas"
+    ],
     "name:fin_x_preferred":[
         "Delmas"
     ],
     "name:fra_x_preferred":[
+        "Delmas"
+    ],
+    "name:gla_x_preferred":[
+        "Delmas"
+    ],
+    "name:gle_x_preferred":[
+        "Delmas"
+    ],
+    "name:glg_x_preferred":[
+        "Delmas"
+    ],
+    "name:glv_x_preferred":[
         "Delmas"
     ],
     "name:guj_x_preferred":[
@@ -56,7 +116,16 @@
     "name:hin_x_preferred":[
         "\u0921\u0947\u0932\u092e\u093e\u0938"
     ],
+    "name:hrv_x_preferred":[
+        "Delmas"
+    ],
+    "name:hun_x_preferred":[
+        "Delmas"
+    ],
     "name:ind_x_preferred":[
+        "Delmas"
+    ],
+    "name:isl_x_preferred":[
         "Delmas"
     ],
     "name:ita_x_preferred":[
@@ -77,10 +146,19 @@
     "name:lit_x_preferred":[
         "Delmasas"
     ],
+    "name:ltz_x_preferred":[
+        "Delmas"
+    ],
     "name:mar_x_preferred":[
         "\u0921\u093f\u0932\u094d\u092e\u093e\u0938"
     ],
+    "name:mlt_x_preferred":[
+        "Delmas"
+    ],
     "name:msa_x_preferred":[
+        "Delmas"
+    ],
+    "name:nan_x_preferred":[
         "Delmas"
     ],
     "name:nld_x_preferred":[
@@ -95,10 +173,22 @@
     "name:nor_x_preferred":[
         "Delmas"
     ],
+    "name:nrm_x_preferred":[
+        "Delmas"
+    ],
+    "name:oci_x_preferred":[
+        "Delmas"
+    ],
+    "name:pms_x_preferred":[
+        "Delmas"
+    ],
     "name:pol_x_preferred":[
         "Delmas"
     ],
     "name:por_x_preferred":[
+        "Delmas"
+    ],
+    "name:roh_x_preferred":[
         "Delmas"
     ],
     "name:ron_x_preferred":[
@@ -113,10 +203,22 @@
     "name:sin_x_preferred":[
         "\u0da9\u0dd9\u0dbd\u0dca\u0db8\u0dcf\u0dc3\u0dca"
     ],
+    "name:slk_x_preferred":[
+        "Delmas"
+    ],
+    "name:slv_x_preferred":[
+        "Delmas"
+    ],
     "name:spa_x_preferred":[
         "Delmas"
     ],
+    "name:sqi_x_preferred":[
+        "Delmas"
+    ],
     "name:swe_x_preferred":[
+        "Delmas"
+    ],
+    "name:tah_x_preferred":[
         "Delmas"
     ],
     "name:tam_x_preferred":[
@@ -137,14 +239,26 @@
     "name:urd_x_preferred":[
         "\u062f\u06cc\u0644\u0645\u0627\u0633"
     ],
+    "name:vec_x_preferred":[
+        "Delmas"
+    ],
     "name:vie_x_preferred":[
         "Delmas"
     ],
     "name:war_x_preferred":[
         "Delmas"
     ],
+    "name:wln_x_preferred":[
+        "Delmas"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d3\u10d4\u10da\u10db\u10d0\u10e1\u10d8"
+    ],
     "name:zho_x_preferred":[
         "\u5fb7\u723e\u99ac\u65af"
+    ],
+    "name:zul_x_preferred":[
+        "Delmas"
     ],
     "qs:gn_country":"HT",
     "qs:gn_fcode":"ADM3",
@@ -198,7 +312,7 @@
         }
     ],
     "wof:id":421179835,
-    "wof:lastmodified":1566648899,
+    "wof:lastmodified":1690930607,
     "wof:name":"Delmas",
     "wof:parent_id":1091686735,
     "wof:placetype":"locality",

--- a/data/421/180/249/421180249.geojson
+++ b/data/421/180/249/421180249.geojson
@@ -32,6 +32,9 @@
     "name:deu_x_preferred":[
         "Marmelade"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03b1\u03c1\u03bc\u03b5\u03bb\u03ac\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Marmelade"
     ],
@@ -48,6 +51,9 @@
         "\u0544\u0561\u0580\u0574\u0565\u056c\u0565\u0575\u0564"
     ],
     "name:ita_x_preferred":[
+        "Marmelade"
+    ],
+    "name:nan_x_preferred":[
         "Marmelade"
     ],
     "name:nld_x_preferred":[
@@ -122,7 +128,7 @@
         }
     ],
     "wof:id":421180249,
-    "wof:lastmodified":1566648894,
+    "wof:lastmodified":1690930601,
     "wof:name":"Marmelade",
     "wof:parent_id":1091686583,
     "wof:placetype":"locality",

--- a/data/421/180/251/421180251.geojson
+++ b/data/421/180/251/421180251.geojson
@@ -26,6 +26,9 @@
     "name:deu_x_preferred":[
         "Ma\u00efssade"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03b1\u03ca\u03c3\u03ac\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Ma\u00efssade"
     ],
@@ -36,6 +39,9 @@
         "Mayisad"
     ],
     "name:ita_x_preferred":[
+        "Ma\u00efssade"
+    ],
+    "name:nan_x_preferred":[
         "Ma\u00efssade"
     ],
     "name:nld_x_preferred":[
@@ -101,7 +107,7 @@
         }
     ],
     "wof:id":421180251,
-    "wof:lastmodified":1566648893,
+    "wof:lastmodified":1690930600,
     "wof:name":"Ma\u00efssade",
     "wof:parent_id":1091686313,
     "wof:placetype":"locality",

--- a/data/421/180/253/421180253.geojson
+++ b/data/421/180/253/421180253.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Limonade"
     ],
+    "name:ell_x_preferred":[
+        "\u039b\u03b9\u03bc\u03bf\u03bd\u03ac\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Limonade"
     ],
@@ -38,7 +41,13 @@
     "name:jpn_x_preferred":[
         "\u30ea\u30e2\u30ca\u30fc\u30c7"
     ],
+    "name:nan_x_preferred":[
+        "Limonade"
+    ],
     "name:nld_x_preferred":[
+        "Limonade"
+    ],
+    "name:pol_x_preferred":[
         "Limonade"
     ],
     "name:por_x_preferred":[
@@ -103,7 +112,7 @@
         }
     ],
     "wof:id":421180253,
-    "wof:lastmodified":1566648894,
+    "wof:lastmodified":1690930601,
     "wof:name":"Limonade",
     "wof:parent_id":1091686431,
     "wof:placetype":"locality",

--- a/data/421/180/255/421180255.geojson
+++ b/data/421/180/255/421180255.geojson
@@ -26,6 +26,9 @@
     "name:cpe_x_preferred":[
         "Rankit"
     ],
+    "name:ell_x_preferred":[
+        "\u03a1\u03b1\u03bd\u03ba\u03af\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Ranquitte"
     ],
@@ -36,6 +39,9 @@
         "Rankit"
     ],
     "name:ita_x_preferred":[
+        "Ranquitte"
+    ],
+    "name:nan_x_preferred":[
         "Ranquitte"
     ],
     "name:nld_x_preferred":[
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":421180255,
-    "wof:lastmodified":1566648894,
+    "wof:lastmodified":1690930601,
     "wof:name":"Ranquitte",
     "wof:parent_id":1091686137,
     "wof:placetype":"locality",

--- a/data/421/180/257/421180257.geojson
+++ b/data/421/180/257/421180257.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Pilate"
     ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03b9\u03bb\u03ac\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Pilate"
     ],
@@ -33,6 +36,12 @@
         "Pilat"
     ],
     "name:ita_x_preferred":[
+        "Pilate"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d4\u30e9\u30c8"
+    ],
+    "name:nan_x_preferred":[
         "Pilate"
     ],
     "name:nld_x_preferred":[
@@ -98,7 +107,7 @@
         }
     ],
     "wof:id":421180257,
-    "wof:lastmodified":1566648893,
+    "wof:lastmodified":1690930600,
     "wof:name":"Pilate",
     "wof:parent_id":1091686691,
     "wof:placetype":"locality",

--- a/data/421/182/505/421182505.geojson
+++ b/data/421/182/505/421182505.geojson
@@ -20,11 +20,17 @@
     "name:ara_x_preferred":[
         "\u0645\u064a\u0631\u0628\u0627\u0644\u064a\u0647"
     ],
+    "name:cat_x_preferred":[
+        "Mirebalais"
+    ],
     "name:ceb_x_preferred":[
         "Mirebalais"
     ],
     "name:deu_x_preferred":[
         "Mirebalais"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03b9\u03c1\u03bc\u03c0\u03b1\u03bb\u03b1\u03af"
     ],
     "name:eng_x_preferred":[
         "Mirebalais"
@@ -36,6 +42,9 @@
         "Mibal\u00e8"
     ],
     "name:ita_x_preferred":[
+        "Mirebalais"
+    ],
+    "name:nan_x_preferred":[
         "Mirebalais"
     ],
     "name:nld_x_preferred":[
@@ -50,11 +59,20 @@
     "name:ron_x_preferred":[
         "Mirebalais"
     ],
+    "name:rus_x_preferred":[
+        "\u041c\u0438\u0440\u0431\u0430\u043b\u0435"
+    ],
     "name:spa_x_preferred":[
         "Mirebalais"
     ],
     "name:swe_x_preferred":[
         "Mirebalais"
+    ],
+    "name:szl_x_preferred":[
+        "Mirebalais"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0456\u0440\u0435\u0431\u0430\u043b\u0435"
     ],
     "name:und_x_variant":[
         "Bourg Saint Louis"
@@ -112,7 +130,7 @@
         }
     ],
     "wof:id":421182505,
-    "wof:lastmodified":1566648900,
+    "wof:lastmodified":1690930608,
     "wof:name":"Mirebalais",
     "wof:parent_id":1091686673,
     "wof:placetype":"locality",

--- a/data/421/185/845/421185845.geojson
+++ b/data/421/185/845/421185845.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Roche-\u00e0-Bateau"
     ],
+    "name:ell_x_preferred":[
+        "\u03a1\u03bf\u03c2-\u03b1-\u039c\u03c0\u03b1\u03c4\u03ce"
+    ],
     "name:eng_x_preferred":[
         "Roche-\u00e0-Bateaux"
     ],
@@ -33,6 +36,12 @@
         "W\u00f2chabato"
     ],
     "name:ita_x_preferred":[
+        "Roche-\u00e0-Bateaux"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a6\u30a9\u30b7\u30e3\u30d0\u30c8\u30fc"
+    ],
+    "name:nan_x_preferred":[
         "Roche-\u00e0-Bateaux"
     ],
     "name:nld_x_preferred":[
@@ -101,7 +110,7 @@
         }
     ],
     "wof:id":421185845,
-    "wof:lastmodified":1566648901,
+    "wof:lastmodified":1690930610,
     "wof:name":"Roche-\u00c0-Bateau",
     "wof:parent_id":1091686543,
     "wof:placetype":"locality",

--- a/data/421/185/847/421185847.geojson
+++ b/data/421/185/847/421185847.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Quartier-Morin"
     ],
+    "name:ell_x_preferred":[
+        "\u039a\u03b1\u03c1\u03c4\u03b9\u03ad-\u039c\u03bf\u03c1\u03ad\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Quartier-Morin"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30ab\u30eb\u30c6\u30a3\u30a8\uff1d\u30e2\u30e9\u30f3"
+    ],
+    "name:nan_x_preferred":[
+        "Quartier-Morin"
     ],
     "name:nld_x_preferred":[
         "Quartier-Morin"
@@ -61,6 +67,9 @@
     ],
     "name:und_x_variant":[
         "Qartier-Morin"
+    ],
+    "name:zho_x_preferred":[
+        "\u5938\u63d0\u4e9e\u83ab\u6797"
     ],
     "qs:gn_country":"HT",
     "qs:gn_fcode":"PPL",
@@ -109,7 +118,7 @@
         }
     ],
     "wof:id":421185847,
-    "wof:lastmodified":1566648901,
+    "wof:lastmodified":1690930610,
     "wof:name":"Quartier Morin",
     "wof:parent_id":1091686431,
     "wof:placetype":"locality",

--- a/data/421/186/241/421186241.geojson
+++ b/data/421/186/241/421186241.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0628\u064a\u0644\u064a \u0622\u0646\u0633"
     ],
+    "name:cat_x_preferred":[
+        "Belle Anse"
+    ],
     "name:ceb_x_preferred":[
         "Belle-Anse"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b5\u03bb-\u0391\u03bd\u03c2"
     ],
     "name:eng_x_preferred":[
         "Belle-Anse"
@@ -36,6 +42,12 @@
         "Belans"
     ],
     "name:ita_x_preferred":[
+        "Belle-Anse"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d9\u30e9\u30f3\u30b9"
+    ],
+    "name:nan_x_preferred":[
         "Belle-Anse"
     ],
     "name:nld_x_preferred":[
@@ -104,7 +116,7 @@
         }
     ],
     "wof:id":421186241,
-    "wof:lastmodified":1566648894,
+    "wof:lastmodified":1690930602,
     "wof:name":"Belle-Anse",
     "wof:parent_id":1091686107,
     "wof:placetype":"locality",

--- a/data/421/186/493/421186493.geojson
+++ b/data/421/186/493/421186493.geojson
@@ -29,6 +29,9 @@
     "name:deu_x_preferred":[
         "Mirago\u00e2ne"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03b9\u03c1\u03b1\u03b3\u03ba\u03bf\u03ac\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Mirago\u00e2ne"
     ],
@@ -49,6 +52,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubbf8\ub77c\uace0\uc548"
+    ],
+    "name:nan_x_preferred":[
+        "Mirago\u00e2ne"
     ],
     "name:nld_x_preferred":[
         "Mirago\u00e2ne"
@@ -85,6 +91,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0645\u06cc\u0631\u0627\u06af\u0648\u0627\u0646"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10db\u10d8\u10e0\u10d0\u10d2\u10dd\u10d0\u10dc\u10d8"
     ],
     "name:zho_x_preferred":[
         "\u7c73\u62c9\u74dc\u7d0d"
@@ -148,7 +157,7 @@
         }
     ],
     "wof:id":421186493,
-    "wof:lastmodified":1582318455,
+    "wof:lastmodified":1690930602,
     "wof:name":"Mirago\u00e2ne",
     "wof:parent_id":1091686629,
     "wof:placetype":"locality",

--- a/data/421/192/059/421192059.geojson
+++ b/data/421/192/059/421192059.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0628\u064a\u0644\u0627\u062f\u064a\u0631\u064a"
     ],
+    "name:cat_x_preferred":[
+        "Belladere"
+    ],
     "name:ceb_x_preferred":[
         "Bellad\u00e8re"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b5\u03bb\u03b1\u03bd\u03c4\u03ad\u03c1"
     ],
     "name:eng_x_preferred":[
         "Bellad\u00e8re"
@@ -37,6 +43,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d9\u30e9\u30c7\u30fc\u30eb"
+    ],
+    "name:nan_x_preferred":[
+        "Bellad\u00e8re"
     ],
     "name:nld_x_preferred":[
         "Bellad\u00e8re"
@@ -61,6 +70,9 @@
     ],
     "name:und_x_variant":[
         "Veladero"
+    ],
+    "name:zho_x_preferred":[
+        "\u8c9d\u62c9\u4ee3\u723e"
     ],
     "qs:gn_country":"HT",
     "qs:gn_fcode":"PPL",
@@ -109,7 +121,7 @@
         }
     ],
     "wof:id":421192059,
-    "wof:lastmodified":1566648892,
+    "wof:lastmodified":1690930599,
     "wof:name":"Bellad\u00e8re",
     "wof:parent_id":1091686393,
     "wof:placetype":"locality",

--- a/data/421/192/063/421192063.geojson
+++ b/data/421/192/063/421192063.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Borgne"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03cc\u03c1\u03bd\u03b9"
+    ],
     "name:eng_x_preferred":[
         "Borgne"
     ],
@@ -36,6 +39,12 @@
         "Ob\u00f2y"
     ],
     "name:ita_x_preferred":[
+        "Borgne"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30aa\u30dc\u30a4"
+    ],
+    "name:nan_x_preferred":[
         "Borgne"
     ],
     "name:nld_x_preferred":[
@@ -100,7 +109,7 @@
         }
     ],
     "wof:id":421192063,
-    "wof:lastmodified":1566648891,
+    "wof:lastmodified":1690930598,
     "wof:name":"Le Borgne",
     "wof:parent_id":1091686137,
     "wof:placetype":"locality",

--- a/data/421/192/067/421192067.geojson
+++ b/data/421/192/067/421192067.geojson
@@ -17,11 +17,17 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:afr_x_preferred":[
+        "Thor"
+    ],
     "name:ang_x_preferred":[
         "\u00deunor"
     ],
     "name:ara_x_preferred":[
         "\u062b\u0648\u0631"
+    ],
+    "name:arg_x_preferred":[
+        "Thor"
     ],
     "name:arz_x_preferred":[
         "\u062b\u0648\u0631"
@@ -35,8 +41,14 @@
     "name:aze_x_preferred":[
         "Tor"
     ],
+    "name:ban_x_preferred":[
+        "Thor"
+    ],
     "name:bar_x_preferred":[
         "Donar"
+    ],
+    "name:bcl_x_preferred":[
+        "Thor"
     ],
     "name:bel_x_preferred":[
         "\u0422\u043e\u0440"
@@ -58,6 +70,9 @@
     ],
     "name:ces_x_preferred":[
         "Th\u00f3r"
+    ],
+    "name:ckb_x_preferred":[
+        "\u062a\u06c6\u0631"
     ],
     "name:dan_x_preferred":[
         "Thor"
@@ -101,6 +116,9 @@
     "name:glg_x_preferred":[
         "Thor"
     ],
+    "name:glv_x_preferred":[
+        "Thor"
+    ],
     "name:got_x_preferred":[
         "\ud800\udf38\ud800\udf3f\ud800\udf3d\ud800\udf30\ud800\udf42/\u00deunar"
     ],
@@ -140,6 +158,12 @@
     "name:kor_x_preferred":[
         "\ud1a0\ub974"
     ],
+    "name:ksh_x_preferred":[
+        "Thor"
+    ],
+    "name:kur_x_preferred":[
+        "Tor"
+    ],
     "name:lat_x_preferred":[
         "Thorus"
     ],
@@ -164,8 +188,14 @@
     "name:mkd_x_preferred":[
         "\u0422\u043e\u0440"
     ],
+    "name:mni_x_preferred":[
+        "\uabca\uabe3\uabd4"
+    ],
     "name:msa_x_preferred":[
         "Thor"
+    ],
+    "name:mya_x_preferred":[
+        "\u101e\u1031\u102c\u103a"
     ],
     "name:nan_x_preferred":[
         "Thor"
@@ -187,6 +217,9 @@
     ],
     "name:oss_x_preferred":[
         "\u0422\u043e\u0440"
+    ],
+    "name:pan_x_preferred":[
+        "\u0a25\u0a4c\u0a30"
     ],
     "name:pol_x_preferred":[
         "Thor"
@@ -214,6 +247,9 @@
     ],
     "name:spa_x_preferred":[
         "Thor"
+    ],
+    "name:sqi_x_preferred":[
+        "Thori"
     ],
     "name:srp_x_preferred":[
         "\u0422\u043e\u0440"
@@ -312,7 +348,7 @@
         }
     ],
     "wof:id":421192067,
-    "wof:lastmodified":1566648892,
+    "wof:lastmodified":1690930599,
     "wof:name":"Thor",
     "wof:parent_id":1091686735,
     "wof:placetype":"locality",

--- a/data/421/193/091/421193091.geojson
+++ b/data/421/193/091/421193091.geojson
@@ -26,6 +26,9 @@
     "name:deu_x_preferred":[
         "Thomassique"
     ],
+    "name:ell_x_preferred":[
+        "\u03a4\u03bf\u03bc\u03b1\u03c3\u03af\u03ba"
+    ],
     "name:eng_x_preferred":[
         "Thomassique"
     ],
@@ -36,6 +39,9 @@
         "Tomasik"
     ],
     "name:ita_x_preferred":[
+        "Thomassique"
+    ],
+    "name:nan_x_preferred":[
         "Thomassique"
     ],
     "name:nld_x_preferred":[
@@ -101,7 +107,7 @@
         }
     ],
     "wof:id":421193091,
-    "wof:lastmodified":1566648892,
+    "wof:lastmodified":1690930599,
     "wof:name":"Thomassique",
     "wof:parent_id":1091687123,
     "wof:placetype":"locality",

--- a/data/421/194/349/421194349.geojson
+++ b/data/421/194/349/421194349.geojson
@@ -26,6 +26,9 @@
     "name:deu_x_preferred":[
         "Milot"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03b9\u03bb\u03cc"
+    ],
     "name:eng_x_preferred":[
         "Milot"
     ],
@@ -35,11 +38,17 @@
     "name:hat_x_preferred":[
         "Milo"
     ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d9\u05dc\u05d5"
+    ],
     "name:ita_x_preferred":[
         "Milot"
     ],
     "name:jpn_x_preferred":[
         "\u30df\u30ed"
+    ],
+    "name:nan_x_preferred":[
+        "Milot"
     ],
     "name:nld_x_preferred":[
         "Milot"
@@ -109,7 +118,7 @@
         }
     ],
     "wof:id":421194349,
-    "wof:lastmodified":1566648892,
+    "wof:lastmodified":1690930599,
     "wof:name":"Milot",
     "wof:parent_id":1091686325,
     "wof:placetype":"locality",

--- a/data/421/194/351/421194351.geojson
+++ b/data/421/194/351/421194351.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0641\u0648\u0631\u062a \u0644\u064a\u0628\u0631\u062a\u064a"
     ],
+    "name:cat_x_preferred":[
+        "Fort Liberte"
+    ],
+    "name:ceb_x_preferred":[
+        "Fort Libert\u00e9"
+    ],
     "name:ces_x_preferred":[
         "Fort-Libert\u00e9"
     ],
@@ -28,6 +34,9 @@
     ],
     "name:deu_x_preferred":[
         "Fort-Libert\u00e9"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a6\u03bf\u03c1-\u039b\u03b9\u03bc\u03c0\u03b5\u03c1\u03c4\u03ad"
     ],
     "name:eng_x_preferred":[
         "Fort-Libert\u00e9"
@@ -44,6 +53,9 @@
     "name:hat_x_preferred":[
         "F\u00f2lib\u00e8te"
     ],
+    "name:heb_x_preferred":[
+        "\u05e4\u05d5\u05e8\u05d8 \u05dc\u05d9\u05d1\u05e8\u05d8\u05d9"
+    ],
     "name:ita_x_preferred":[
         "Fort-Libert\u00e9"
     ],
@@ -52,6 +64,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud3ec\ub974\ub9ac\ubca0\ub974\ud14c"
+    ],
+    "name:nan_x_preferred":[
+        "Fort-Libert\u00e9"
     ],
     "name:nld_x_preferred":[
         "Fort-Libert\u00e9"
@@ -79,6 +94,9 @@
     ],
     "name:spa_x_preferred":[
         "Fuerte Libertad"
+    ],
+    "name:swe_x_preferred":[
+        "Fort Libert\u00e9"
     ],
     "name:tha_x_preferred":[
         "\u0e1f\u0e2d\u0e23\u0e4c-\u0e25\u0e35\u0e41\u0e1a\u0e23\u0e4c\u0e40\u0e15"
@@ -236,7 +254,7 @@
         }
     ],
     "wof:id":421194351,
-    "wof:lastmodified":1566648892,
+    "wof:lastmodified":1690930599,
     "wof:name":"Fort Libert\u00e9",
     "wof:parent_id":1091686227,
     "wof:placetype":"locality",

--- a/data/421/197/791/421197791.geojson
+++ b/data/421/197/791/421197791.geojson
@@ -20,8 +20,20 @@
     "name:ara_x_preferred":[
         "\u0628\u064a\u062a\u064a\u062a \u063a\u0648\u0627\u0641"
     ],
+    "name:ast_x_preferred":[
+        "Petit-Go\u00e2ve"
+    ],
+    "name:cat_x_preferred":[
+        "Petit Goave"
+    ],
     "name:ceb_x_preferred":[
         "Tigwav"
+    ],
+    "name:deu_x_preferred":[
+        "Petit-Go\u00e2ve"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03b5\u03c4\u03af-\u0393\u03ba\u03bf\u03ac\u03b2"
     ],
     "name:eng_x_preferred":[
         "Petit-Go\u00e2ve"
@@ -37,6 +49,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d7\u30c1\u30b4\u30a2\u30fc\u30d6"
+    ],
+    "name:nan_x_preferred":[
+        "Petit-Go\u00e2ve"
     ],
     "name:nld_x_preferred":[
         "Petit-Go\u00e2ve"
@@ -56,11 +71,17 @@
     "name:ron_x_preferred":[
         "Petit-Go\u00e2ve"
     ],
+    "name:rus_x_preferred":[
+        "\u041f\u0442\u0438-\u0413\u043e\u0430\u0432"
+    ],
     "name:spa_x_preferred":[
         "Petit-Go\u00e2ve"
     ],
     "name:swe_x_preferred":[
         "Petit-Go\u00e2ve"
+    ],
+    "name:swe_x_variant":[
+        "Tigwav"
     ],
     "name:ukr_x_preferred":[
         "\u041f\u0435\u0442\u0456-\u0413\u043e\u0430\u0432"
@@ -121,7 +142,7 @@
         }
     ],
     "wof:id":421197791,
-    "wof:lastmodified":1566648896,
+    "wof:lastmodified":1690930603,
     "wof:name":"Petit Go\u00e2ve",
     "wof:parent_id":1091687199,
     "wof:placetype":"locality",

--- a/data/421/197/793/421197793.geojson
+++ b/data/421/197/793/421197793.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Lenbe"
     ],
+    "name:ell_x_preferred":[
+        "\u039b\u03b1\u03bc\u03c0\u03ad"
+    ],
     "name:eng_x_preferred":[
         "Limb\u00e9"
     ],
@@ -33,6 +36,12 @@
         "Lenbe"
     ],
     "name:ita_x_preferred":[
+        "Limb\u00e9"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30e9\u30f3\u30d9"
+    ],
+    "name:nan_x_preferred":[
         "Limb\u00e9"
     ],
     "name:nld_x_preferred":[
@@ -116,7 +125,7 @@
         }
     ],
     "wof:id":421197793,
-    "wof:lastmodified":1566648896,
+    "wof:lastmodified":1690930604,
     "wof:name":"Limb\u00e9",
     "wof:parent_id":1091687057,
     "wof:placetype":"locality",

--- a/data/421/197/797/421197797.geojson
+++ b/data/421/197/797/421197797.geojson
@@ -26,6 +26,9 @@
     "name:ceb_x_preferred":[
         "Les Anglais"
     ],
+    "name:ell_x_preferred":[
+        "\u039b\u03b5\u03b6 \u0391\u03bd\u03b3\u03ba\u03bb\u03b1\u03af"
+    ],
     "name:eng_x_preferred":[
         "Les Anglais"
     ],
@@ -39,6 +42,12 @@
         "Les Anglais"
     ],
     "name:ita_x_preferred":[
+        "Les Anglais"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b6\u30f3\u30b0\u30ec"
+    ],
+    "name:nan_x_preferred":[
         "Les Anglais"
     ],
     "name:nld_x_preferred":[
@@ -109,7 +118,7 @@
         }
     ],
     "wof:id":421197797,
-    "wof:lastmodified":1566648896,
+    "wof:lastmodified":1690930603,
     "wof:name":"Les Anglais",
     "wof:parent_id":1091686503,
     "wof:placetype":"locality",

--- a/data/421/197/799/421197799.geojson
+++ b/data/421/197/799/421197799.geojson
@@ -20,11 +20,20 @@
     "name:ara_x_preferred":[
         "\u0643\u064a\u0646\u0633\u0643\u0648\u0641"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u064a\u0646\u0633\u0643\u0648\u0641"
+    ],
+    "name:ast_x_preferred":[
+        "Kenscoff"
+    ],
     "name:ceb_x_preferred":[
         "Kenscoff"
     ],
     "name:deu_x_preferred":[
         "Kenscoff"
+    ],
+    "name:ell_x_preferred":[
+        "\u039a\u03b5\u03bd\u03c3\u03ba\u03cc\u03c6"
     ],
     "name:eng_x_preferred":[
         "Kenscoff"
@@ -39,6 +48,12 @@
         "Kensk\u00f2f"
     ],
     "name:ita_x_preferred":[
+        "Kenscoff"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b1\u30f3\u30b9\u30b3\u30d5"
+    ],
+    "name:nan_x_preferred":[
         "Kenscoff"
     ],
     "name:nld_x_preferred":[
@@ -118,7 +133,7 @@
         }
     ],
     "wof:id":421197799,
-    "wof:lastmodified":1566648896,
+    "wof:lastmodified":1690930603,
     "wof:name":"Kenscoff",
     "wof:parent_id":1091686735,
     "wof:placetype":"locality",

--- a/data/421/197/801/421197801.geojson
+++ b/data/421/197/801/421197801.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0631\u0648\u0643\u0633 \u062f\u064a\u0633 \u0628\u0648\u0643\u064a\u062a\u0633"
     ],
+    "name:ast_x_preferred":[
+        "Croix-des-Bouquets"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09cd\u09b0\u0987\u0995\u09cd\u09b8-\u09a6\u09c7\u09b8-\u09ac\u09c1\u0995\u09c7\u099f\u09b8"
     ],
@@ -32,8 +35,14 @@
     "name:dan_x_preferred":[
         "Croix-des-Bouqets"
     ],
+    "name:deu_x_preferred":[
+        "Croix-des-Bouquets"
+    ],
     "name:ell_x_preferred":[
         "\u039a\u03c1\u03cc\u03b9\u03be-\u03bd\u03c4\u03b5\u03c2-\u039c\u03c0\u03bf\u03c5\u03ba\u03ad\u03c4\u03c2"
+    ],
+    "name:ell_x_variant":[
+        "\u039a\u03c1\u03bf\u03c5\u03ac-\u03bd\u03c4\u03b5-\u039c\u03c0\u03bf\u03c5\u03ba\u03ad"
     ],
     "name:eng_x_preferred":[
         "Croix-des-Bouquets"
@@ -59,6 +68,9 @@
     "name:hin_x_preferred":[
         "\u0915\u094d\u0930\u0942\u0906 \u0926\u093f \u092c\u0942\u0915\u0947"
     ],
+    "name:hye_x_preferred":[
+        "\u053f\u0580\u0578\u0582\u0561 \u0564\u0565 \u0532\u0578\u0582\u056f\u0565"
+    ],
     "name:ind_x_preferred":[
         "Croix-des-Bouquets"
     ],
@@ -67,6 +79,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30af\u30ed\u30ef\u30fb\u30c7\u30fb\u30d6\u30fc\u30b1"
+    ],
+    "name:jpn_x_variant":[
+        "\u30af\u30ed\u30ef\uff1d\u30c7\uff1d\u30d6\u30fc\u30b1"
     ],
     "name:kan_x_preferred":[
         "\u0c95\u0ccd\u0cb0\u0ccb\u0c95\u0ccd\u0cb8\u0ccd-\u0ca1\u0cc6\u0cb8\u0ccd-\u0cac\u0cca\u0c95\u0cc6\u0c9f\u0ccd\u0cb8\u0ccd"
@@ -131,6 +146,9 @@
     "name:tha_x_preferred":[
         "\u0e25\u0e32 \u0e04\u0e23\u0e31\u0e27 \u0e40\u0e14 \u0e01\u0e32\u0e23\u0e4c\u0e14"
     ],
+    "name:tha_x_variant":[
+        "\u0e04\u0e23\u0e31\u0e27-\u0e40\u0e14-\u0e1a\u0e39\u0e41\u0e01"
+    ],
     "name:tur_x_preferred":[
         "Croix-des-Bouquets"
     ],
@@ -193,7 +211,7 @@
         }
     ],
     "wof:id":421197801,
-    "wof:lastmodified":1566648896,
+    "wof:lastmodified":1690930604,
     "wof:name":"Croix des Bouquets",
     "wof:parent_id":1091687379,
     "wof:placetype":"locality",

--- a/data/421/198/251/421198251.geojson
+++ b/data/421/198/251/421198251.geojson
@@ -20,8 +20,17 @@
     "name:ara_x_preferred":[
         "\u0628\u0644\u064a\u0646 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629"
     ],
+    "name:ceb_x_preferred":[
+        "Plaine du Nord"
+    ],
+    "name:dan_x_preferred":[
+        "Plaine-du-Nord"
+    ],
     "name:deu_x_preferred":[
         "Pl\u00e8n din\u00f2"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03bb\u03b1\u03b9\u03bd-\u03bd\u03c4\u03c5-\u039d\u03bf\u03c1"
     ],
     "name:eng_x_preferred":[
         "Plaine-du-Nord"
@@ -29,13 +38,23 @@
     "name:fra_x_preferred":[
         "Plaine-du-Nord"
     ],
+    "name:gle_x_preferred":[
+        "Plaine-du-Nord"
+    ],
     "name:hat_x_preferred":[
         "Pl\u00e8n din\u00f2"
     ],
     "name:hat_x_variant":[
-        "Pl\u00e8n di N\u00f2"
+        "Pl\u00e8n di N\u00f2",
+        "Pl\u00e8n Din\u00f2"
+    ],
+    "name:hye_x_preferred":[
+        "\u054a\u056c\u0565\u0575\u0576 \u0564\u0578\u0582 \u0546\u0578\u0580\u0564"
     ],
     "name:ita_x_preferred":[
+        "Plaine-du-Nord"
+    ],
+    "name:nan_x_preferred":[
         "Plaine-du-Nord"
     ],
     "name:nld_x_preferred":[
@@ -49,6 +68,9 @@
     ],
     "name:spa_x_preferred":[
         "Plaine-du-Nord"
+    ],
+    "name:swe_x_preferred":[
+        "Plaine du Nord"
     ],
     "qs:gn_country":"HT",
     "qs:gn_fcode":"PPL",
@@ -97,7 +119,7 @@
         }
     ],
     "wof:id":421198251,
-    "wof:lastmodified":1566648895,
+    "wof:lastmodified":1690930602,
     "wof:name":"Plaine du Nord",
     "wof:parent_id":1091686325,
     "wof:placetype":"locality",

--- a/data/421/198/253/421198253.geojson
+++ b/data/421/198/253/421198253.geojson
@@ -26,6 +26,9 @@
     "name:dan_x_preferred":[
         "Gressier"
     ],
+    "name:ell_x_preferred":[
+        "\u0393\u03ba\u03c1\u03b5\u03c3\u03b9\u03ad"
+    ],
     "name:eng_x_preferred":[
         "Gressier"
     ],
@@ -35,7 +38,16 @@
     "name:hat_x_preferred":[
         "Gresye"
     ],
+    "name:heb_x_preferred":[
+        "\u05d2\u05e8\u05d0\u05e1\u05d9\u05d9\u05d4"
+    ],
     "name:ita_x_preferred":[
+        "Gressier"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b0\u30ec\u30b7\u30a8"
+    ],
+    "name:nan_x_preferred":[
         "Gressier"
     ],
     "name:nld_x_preferred":[
@@ -61,6 +73,9 @@
     ],
     "name:zho_x_preferred":[
         "\u683c\u745e\u65af\u5c14"
+    ],
+    "name:zho_x_variant":[
+        "\u683c\u96f7\u897f\u8036"
     ],
     "qs:gn_country":"HT",
     "qs:gn_fcode":"PPL",
@@ -111,7 +126,7 @@
         }
     ],
     "wof:id":421198253,
-    "wof:lastmodified":1566648895,
+    "wof:lastmodified":1690930603,
     "wof:name":"Gressier",
     "wof:parent_id":85671967,
     "wof:placetype":"locality",

--- a/data/421/198/255/421198255.geojson
+++ b/data/421/198/255/421198255.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Grande Saline"
     ],
+    "name:ell_x_preferred":[
+        "\u0393\u03ba\u03c1\u03b1\u03bd\u03c4 \u03a3\u03b1\u03bb\u03af\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Grande Saline"
     ],
@@ -33,6 +36,9 @@
         "Grann Salin"
     ],
     "name:ita_x_preferred":[
+        "Grande-Saline"
+    ],
+    "name:nan_x_preferred":[
         "Grande-Saline"
     ],
     "name:nld_x_preferred":[
@@ -101,7 +107,7 @@
         }
     ],
     "wof:id":421198255,
-    "wof:lastmodified":1566648895,
+    "wof:lastmodified":1690930603,
     "wof:name":"Grande Saline",
     "wof:parent_id":1091687127,
     "wof:placetype":"locality",

--- a/data/421/198/447/421198447.geojson
+++ b/data/421/198/447/421198447.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Bombardopolis"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03bf\u03bc\u03c0\u03b1\u03c1\u03bd\u03c4\u03bf\u03c0\u03bf\u03bb\u03af\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Bombardopolis"
     ],
@@ -33,6 +36,12 @@
         "Bonbadopolis"
     ],
     "name:ita_x_preferred":[
+        "Bombardopolis"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30dc\u30f3\u30d0\u30eb\u30c9\u30dd\u30ea\u30b9"
+    ],
+    "name:nan_x_preferred":[
         "Bombardopolis"
     ],
     "name:nld_x_preferred":[
@@ -55,6 +64,9 @@
     ],
     "name:und_x_variant":[
         "Ville de Bombardopolis"
+    ],
+    "name:zho_x_preferred":[
+        "\u9f90\u5df4\u591a\u6ce2\u5229\u65af"
     ],
     "qs:gn_country":"HT",
     "qs:gn_fcode":"PPL",
@@ -104,7 +116,7 @@
         }
     ],
     "wof:id":421198447,
-    "wof:lastmodified":1566648895,
+    "wof:lastmodified":1690930602,
     "wof:name":"Bombardopolis",
     "wof:parent_id":1091686921,
     "wof:placetype":"locality",

--- a/data/421/199/843/421199843.geojson
+++ b/data/421/199/843/421199843.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Port-\u00e0-Piment"
     ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03bf\u03c1-\u03b1-\u03a0\u03b9\u03bc\u03ac\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Port-\u00e0-Piment"
     ],
@@ -35,6 +38,12 @@
     "name:ita_x_preferred":[
         "Port-\u00e0-Piment"
     ],
+    "name:jpn_x_preferred":[
+        "\u30dd\u30fc\u30bf\u30d4\u30de\u30f3"
+    ],
+    "name:nan_x_preferred":[
+        "Port-\u00e0-Piment"
+    ],
     "name:nld_x_preferred":[
         "Port-\u00e0-Piment"
     ],
@@ -43,6 +52,9 @@
     ],
     "name:ron_x_preferred":[
         "Port-\u00e0-Piment"
+    ],
+    "name:rus_x_preferred":[
+        "\u041f\u043e\u0440\u0442-\u0430-\u041f\u0438\u043c\u0430\u043d"
     ],
     "name:spa_x_preferred":[
         "Port-\u00e0-Piment"
@@ -101,7 +113,7 @@
         }
     ],
     "wof:id":421199843,
-    "wof:lastmodified":1566648897,
+    "wof:lastmodified":1690930604,
     "wof:name":"Port-\u00c0-Piment",
     "wof:parent_id":1091686543,
     "wof:placetype":"locality",

--- a/data/421/199/849/421199849.geojson
+++ b/data/421/199/849/421199849.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0631\u062f\u0631\u064a\u0633"
     ],
+    "name:cat_x_preferred":[
+        "Barad\u00e9res"
+    ],
     "name:ceb_x_preferred":[
         "Barad\u00e8res"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b1\u03c1\u03b1\u03bd\u03c4\u03ad\u03c1"
     ],
     "name:eng_x_preferred":[
         "Barad\u00e8res"
@@ -33,6 +39,9 @@
         "Barad\u00e8"
     ],
     "name:ita_x_preferred":[
+        "Barad\u00e8res"
+    ],
+    "name:nan_x_preferred":[
         "Barad\u00e8res"
     ],
     "name:nld_x_preferred":[
@@ -101,7 +110,7 @@
         }
     ],
     "wof:id":421199849,
-    "wof:lastmodified":1566648897,
+    "wof:lastmodified":1690930604,
     "wof:name":"Barad\u00e8res",
     "wof:parent_id":1091687241,
     "wof:placetype":"locality",

--- a/data/421/200/037/421200037.geojson
+++ b/data/421/200/037/421200037.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Bahon"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b1\u03cc\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Bahon"
     ],
@@ -33,6 +36,9 @@
         "Bawon"
     ],
     "name:ita_x_preferred":[
+        "Bahon"
+    ],
+    "name:nan_x_preferred":[
         "Bahon"
     ],
     "name:nld_x_preferred":[
@@ -101,7 +107,7 @@
         }
     ],
     "wof:id":421200037,
-    "wof:lastmodified":1566648897,
+    "wof:lastmodified":1690930605,
     "wof:name":"Bahon",
     "wof:parent_id":1091686273,
     "wof:placetype":"locality",

--- a/data/421/201/191/421201191.geojson
+++ b/data/421/201/191/421201191.geojson
@@ -29,6 +29,9 @@
     "name:ben_x_preferred":[
         "\u099c\u09c7\u09b0\u09c7\u09ae\u09bf"
     ],
+    "name:cat_x_preferred":[
+        "J\u00e9r\u00e9mie"
+    ],
     "name:ceb_x_preferred":[
         "J\u00e9r\u00e9mie"
     ],
@@ -44,6 +47,9 @@
     "name:ell_x_preferred":[
         "\u0396\u03ad\u03c1\u03b5\u03bc\u03b9"
     ],
+    "name:ell_x_variant":[
+        "\u0396\u03b5\u03c1\u03b5\u03bc\u03af"
+    ],
     "name:eng_x_preferred":[
         "J\u00e9r\u00e9mie"
     ],
@@ -57,6 +63,9 @@
         "J\u00e9r\u00e9mie"
     ],
     "name:fra_x_preferred":[
+        "J\u00e9r\u00e9mie"
+    ],
+    "name:glg_x_preferred":[
         "J\u00e9r\u00e9mie"
     ],
     "name:guj_x_preferred":[
@@ -101,6 +110,9 @@
     "name:msa_x_preferred":[
         "Jeremie"
     ],
+    "name:nan_x_preferred":[
+        "J\u00e9r\u00e9mie"
+    ],
     "name:nld_x_preferred":[
         "J\u00e9r\u00e9mie"
     ],
@@ -131,6 +143,9 @@
     "name:swe_x_preferred":[
         "J\u00e9r\u00e9mie"
     ],
+    "name:szl_x_preferred":[
+        "J\u00e9r\u00e9mie"
+    ],
     "name:tam_x_preferred":[
         "\u0b9c\u0bc6\u0bb0\u0bc7\u0bae\u0bbf\u0baf\u0bc7"
     ],
@@ -154,6 +169,9 @@
     ],
     "name:vie_x_preferred":[
         "Jeremie"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10df\u10d4\u10e0\u10d4\u10db\u10d8"
     ],
     "name:zho_x_preferred":[
         "\u71b1\u96f7\u7c73"
@@ -300,7 +318,7 @@
         }
     ],
     "wof:id":421201191,
-    "wof:lastmodified":1566648898,
+    "wof:lastmodified":1690930605,
     "wof:name":"J\u00e9r\u00e9mie",
     "wof:parent_id":1091686323,
     "wof:placetype":"locality",

--- a/data/421/201/205/421201205.geojson
+++ b/data/421/201/205/421201205.geojson
@@ -23,6 +23,12 @@
     "name:ceb_x_preferred":[
         "Cavaillon"
     ],
+    "name:deu_x_preferred":[
+        "Cavaillon"
+    ],
+    "name:ell_x_preferred":[
+        "\u039a\u03b1\u03b2\u03b1\u03b5\u03bb\u03cc\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Cavaellon"
     ],
@@ -34,6 +40,12 @@
     ],
     "name:ita_x_preferred":[
         "Cavaillon"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30ab\u30f4\u30a1\u30a4\u30e8\u30f3"
+    ],
+    "name:nan_x_preferred":[
+        "Cavaellon"
     ],
     "name:nld_x_preferred":[
         "Cavaillon"
@@ -50,7 +62,13 @@
     "name:ron_x_preferred":[
         "Cavaillon"
     ],
+    "name:rus_x_preferred":[
+        "\u041a\u0430\u0432\u0435\u0439\u043e\u043d"
+    ],
     "name:spa_x_preferred":[
+        "Cavaillon"
+    ],
+    "name:swe_x_preferred":[
         "Cavaillon"
     ],
     "name:und_x_variant":[
@@ -58,6 +76,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u97e6\u9686"
+    ],
+    "name:zho_x_variant":[
+        "\u5361\u74e6\u6c38"
     ],
     "qs:gn_country":"HT",
     "qs:gn_fcode":"PPL",
@@ -107,7 +128,7 @@
         }
     ],
     "wof:id":421201205,
-    "wof:lastmodified":1566648897,
+    "wof:lastmodified":1690930605,
     "wof:name":"Cavaillon",
     "wof:parent_id":1091687293,
     "wof:placetype":"locality",

--- a/data/421/201/303/421201303.geojson
+++ b/data/421/201/303/421201303.geojson
@@ -56,6 +56,9 @@
     "name:deu_x_preferred":[
         "M\u00f4le-Saint-Nicolas"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03bf\u03bb-\u03a3\u03b1\u03b9\u03bd-\u039d\u03b9\u03ba\u03bf\u03bb\u03ac"
+    ],
     "name:eng_x_preferred":[
         "M\u00f4le-Saint-Nicolas"
     ],
@@ -143,6 +146,9 @@
     "name:msa_x_preferred":[
         "M\u00f4le-Saint-Nicolas"
     ],
+    "name:nan_x_preferred":[
+        "M\u00f4le-Saint-Nicolas"
+    ],
     "name:nap_x_preferred":[
         "M\u00f4le-Saint-Nicolas"
     ],
@@ -227,6 +233,9 @@
     "name:wol_x_preferred":[
         "M\u00f4le-Saint-Nicolas"
     ],
+    "name:zho_x_preferred":[
+        "\u6469\u5c14\u00b7\u5723\u00b7\u5c3c\u53e4\u62c9\u65af"
+    ],
     "name:zul_x_preferred":[
         "M\u00f4le-Saint-Nicolas"
     ],
@@ -278,7 +287,7 @@
         }
     ],
     "wof:id":421201303,
-    "wof:lastmodified":1566648898,
+    "wof:lastmodified":1690930606,
     "wof:name":"M\u00f4le St.-Nicolas",
     "wof:parent_id":1091686921,
     "wof:placetype":"locality",

--- a/data/421/201/725/421201725.geojson
+++ b/data/421/201/725/421201725.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0631\u062a \u0645\u0627\u0631\u063a\u0648\u062a"
     ],
+    "name:ceb_x_preferred":[
+        "Port Margot"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03bf\u03c1-\u039c\u03b1\u03c1\u03b3\u03ba\u03cc"
+    ],
     "name:eng_x_preferred":[
         "Port-Margot"
     ],
@@ -35,6 +41,9 @@
     "name:jpn_x_preferred":[
         "\u30de\u30ec\u30b4"
     ],
+    "name:nan_x_preferred":[
+        "Port-Margot"
+    ],
     "name:nld_x_preferred":[
         "Port-Margot"
     ],
@@ -44,8 +53,14 @@
     "name:ron_x_preferred":[
         "Port-Margot"
     ],
+    "name:rus_x_preferred":[
+        "\u041f\u043e\u0440\u0442-\u041c\u0430\u0440\u0433\u043e"
+    ],
     "name:spa_x_preferred":[
         "Port-Margot"
+    ],
+    "name:swe_x_preferred":[
+        "Port Margot"
     ],
     "qs:gn_country":"HT",
     "qs:gn_fcode":"PPL",
@@ -94,7 +109,7 @@
         }
     ],
     "wof:id":421201725,
-    "wof:lastmodified":1566648897,
+    "wof:lastmodified":1690930605,
     "wof:name":"Port Margot",
     "wof:parent_id":1091686137,
     "wof:placetype":"locality",

--- a/data/421/201/727/421201727.geojson
+++ b/data/421/201/727/421201727.geojson
@@ -23,6 +23,12 @@
     "name:ceb_x_preferred":[
         "Jean-Rabel"
     ],
+    "name:ceb_x_variant":[
+        "Jean Rabel"
+    ],
+    "name:ell_x_preferred":[
+        "\u0396\u03b1\u03bd-\u03a1\u03b1\u03bc\u03c0\u03ad\u03bb"
+    ],
     "name:eng_x_preferred":[
         "Jean-Rabel"
     ],
@@ -41,6 +47,9 @@
     "name:kor_x_preferred":[
         "\uc7a5\ub77c\ubca8"
     ],
+    "name:nan_x_preferred":[
+        "Jean-Rabel"
+    ],
     "name:nld_x_preferred":[
         "Jean-Rabel"
     ],
@@ -58,6 +67,9 @@
     ],
     "name:swe_x_preferred":[
         "Jean-Rabel"
+    ],
+    "name:swe_x_variant":[
+        "Jean Rabel"
     ],
     "name:und_x_variant":[
         "Ville de Jean Rabel"
@@ -110,7 +122,7 @@
         }
     ],
     "wof:id":421201727,
-    "wof:lastmodified":1566648898,
+    "wof:lastmodified":1690930606,
     "wof:name":"Jean-Rabel",
     "wof:parent_id":1091686921,
     "wof:placetype":"locality",

--- a/data/421/204/647/421204647.geojson
+++ b/data/421/204/647/421204647.geojson
@@ -23,6 +23,12 @@
     "name:ceb_x_preferred":[
         "Torbeck"
     ],
+    "name:deu_x_preferred":[
+        "Torbeck"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a4\u03bf\u03c1\u03bc\u03c0\u03ad\u03ba"
+    ],
     "name:eng_x_preferred":[
         "Torbeck"
     ],
@@ -38,6 +44,9 @@
     "name:jpn_x_preferred":[
         "\u30c8\u30fc\u30d9\u30c3\u30af"
     ],
+    "name:nan_x_preferred":[
+        "Torbeck"
+    ],
     "name:nld_x_preferred":[
         "Torbeck"
     ],
@@ -46,6 +55,9 @@
     ],
     "name:ron_x_preferred":[
         "Torbeck"
+    ],
+    "name:rus_x_preferred":[
+        "\u0422\u043e\u0440\u0431\u0435\u043a"
     ],
     "name:spa_x_preferred":[
         "Torbeck"
@@ -101,7 +113,7 @@
         }
     ],
     "wof:id":421204647,
-    "wof:lastmodified":1566648893,
+    "wof:lastmodified":1690930600,
     "wof:name":"Torbeck",
     "wof:parent_id":1091686479,
     "wof:placetype":"locality",

--- a/data/856/324/33/85632433.geojson
+++ b/data/856/324/33/85632433.geojson
@@ -28,11 +28,17 @@
     "mz:is_current":1,
     "mz:max_zoom":9.0,
     "mz:min_zoom":4.0,
+    "name:abk_x_preferred":[
+        "\u0413\u0430\u0438\u0442\u0438"
+    ],
     "name:afr_x_preferred":[
         "Ha\u00efti"
     ],
     "name:aka_x_preferred":[
         "Heiti"
+    ],
+    "name:aka_x_variant":[
+        "Haiti"
     ],
     "name:als_x_preferred":[
         "Haiti"
@@ -43,8 +49,14 @@
     "name:amh_x_variant":[
         "\u1200\u12ed\u1272"
     ],
+    "name:ami_x_preferred":[
+        "Haiti"
+    ],
     "name:ang_x_preferred":[
         "Hait\u012beg"
+    ],
+    "name:anp_x_preferred":[
+        "\u0939\u0948\u0924\u0940"
     ],
     "name:ara_x_preferred":[
         "\u0647\u0627\u064a\u062a\u064a"
@@ -64,6 +76,12 @@
     "name:ast_x_preferred":[
         "Hait\u00ed"
     ],
+    "name:atj_x_preferred":[
+        "Haiti"
+    ],
+    "name:avk_x_preferred":[
+        "Ayitia"
+    ],
     "name:aym_x_preferred":[
         "Ayti"
     ],
@@ -78,6 +96,9 @@
     ],
     "name:bam_x_preferred":[
         "Ayiti"
+    ],
+    "name:ban_x_preferred":[
+        "Haiti"
     ],
     "name:bar_x_preferred":[
         "Haiti"
@@ -96,6 +117,9 @@
     ],
     "name:bho_x_preferred":[
         "\u0939\u0948\u0924\u0940"
+    ],
+    "name:bis_x_preferred":[
+        "Haiti"
     ],
     "name:bjn_x_preferred":[
         "Haiti"
@@ -161,6 +185,9 @@
         "Haiti"
     ],
     "name:cym_x_preferred":[
+        "Haiti"
+    ],
+    "name:dag_x_preferred":[
         "Haiti"
     ],
     "name:dan_x_preferred":[
@@ -260,6 +287,12 @@
     "name:ful_x_preferred":[
         "Haytii"
     ],
+    "name:ful_x_variant":[
+        "Hayti"
+    ],
+    "name:fur_x_preferred":[
+        "Haiti"
+    ],
     "name:gag_x_preferred":[
         "Haiti"
     ],
@@ -289,6 +322,9 @@
     ],
     "name:gom_x_preferred":[
         "\u0939\u0948\u0924\u0940"
+    ],
+    "name:gpe_x_preferred":[
+        "Haiti"
     ],
     "name:grn_x_preferred":[
         "Haiti"
@@ -389,6 +425,9 @@
     "name:kaa_x_preferred":[
         "Gaiti"
     ],
+    "name:kab_x_preferred":[
+        "Hayti"
+    ],
     "name:kal_x_preferred":[
         "Haiti"
     ],
@@ -429,6 +468,9 @@
         "\uc544\ub2c8\ud2f0",
         "\ud558\uc774\ud2f0"
     ],
+    "name:krj_x_preferred":[
+        "Ayti"
+    ],
     "name:kur_x_preferred":[
         "Ha\u00eet\u00ee"
     ],
@@ -462,6 +504,9 @@
     "name:lit_x_preferred":[
         "Haitis"
     ],
+    "name:lld_x_preferred":[
+        "Haiti"
+    ],
     "name:lmo_x_preferred":[
         "Haiti"
     ],
@@ -480,6 +525,9 @@
     "name:lzh_x_preferred":[
         "\u6d77\u5730"
     ],
+    "name:mad_x_preferred":[
+        "Haiti"
+    ],
     "name:mal_x_preferred":[
         "\u0d39\u0d46\u0d2f\u0d4d\u0d31\u0d4d\u0d31\u0d3f"
     ],
@@ -489,8 +537,14 @@
     "name:mar_x_preferred":[
         "\u0939\u0948\u0924\u0940"
     ],
+    "name:mdf_x_preferred":[
+        "\u0413\u0430\u0438\u0442\u0438"
+    ],
     "name:mhr_x_preferred":[
         "\u0413\u0430\u0438\u0442\u0438"
+    ],
+    "name:min_x_preferred":[
+        "Haiti"
     ],
     "name:mkd_x_preferred":[
         "\u0425\u0430\u0438\u0442\u0438"
@@ -501,11 +555,20 @@
     "name:mlt_x_preferred":[
         "\u0126aiti"
     ],
+    "name:mlt_x_variant":[
+        "Haiti"
+    ],
+    "name:mni_x_preferred":[
+        "\uabcd\uabe5\uabe2\uabc7\uabe4"
+    ],
     "name:mon_x_preferred":[
         "\u0413\u0430\u0438\u0442\u0438"
     ],
     "name:mon_x_variant":[
         "\u0413\u0430\u0439\u0442\u0438"
+    ],
+    "name:mri_x_preferred":[
+        "Haiti"
     ],
     "name:mrj_x_preferred":[
         "\u0413\u0430\u0438\u0442\u0438"
@@ -518,6 +581,9 @@
     ],
     "name:mya_x_variant":[
         "\u101f\u1031\u1010\u102e"
+    ],
+    "name:myv_x_preferred":[
+        "\u0413\u0430\u0438\u0442\u0438 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430\u0441\u044c"
     ],
     "name:mzn_x_preferred":[
         "\u0647\u0627\u0626\u06cc\u062a\u06cc"
@@ -598,6 +664,9 @@
     "name:pap_x_preferred":[
         "Haiti"
     ],
+    "name:pcd_x_preferred":[
+        "Ha\u00efti"
+    ],
     "name:pih_x_preferred":[
         "Haiti"
     ],
@@ -627,6 +696,9 @@
     ],
     "name:que_x_variant":[
         "Ayti"
+    ],
+    "name:rmy_x_preferred":[
+        "Haiti"
     ],
     "name:roh_x_preferred":[
         "Haiti"
@@ -673,6 +745,12 @@
     "name:sgs_x_preferred":[
         "Hait\u0117s"
     ],
+    "name:sgs_x_variant":[
+        "Ha\u0117tis"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1081\u1031\u1038\u1010\u102e\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0dc4\u0dd9\u0dba\u0dd2\u0da7\u0dd2"
     ],
@@ -691,7 +769,13 @@
     "name:sme_x_preferred":[
         "Haiti"
     ],
+    "name:smn_x_preferred":[
+        "Haiti"
+    ],
     "name:smo_x_preferred":[
+        "Haiti"
+    ],
+    "name:sms_x_preferred":[
         "Haiti"
     ],
     "name:sna_x_preferred":[
@@ -782,7 +866,13 @@
     "name:tir_x_preferred":[
         "\u1200\u12ed\u1272"
     ],
+    "name:tok_x_preferred":[
+        "ma Awisi"
+    ],
     "name:ton_x_preferred":[
+        "Haiti"
+    ],
+    "name:trv_x_preferred":[
         "Haiti"
     ],
     "name:tuk_x_preferred":[
@@ -842,6 +932,9 @@
     ],
     "name:wuu_x_preferred":[
         "\u6d77\u5730"
+    ],
+    "name:xho_x_preferred":[
+        "I-Haiti"
     ],
     "name:xmf_x_preferred":[
         "\u10f0\u10d0\u10d8\u10e2\u10d8"
@@ -1093,7 +1186,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1617827402,
+    "wof:lastmodified":1690930590,
     "wof:name":"Haiti",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/719/33/85671933.geojson
+++ b/data/856/719/33/85671933.geojson
@@ -60,6 +60,9 @@
     "name:ell_x_preferred":[
         "\u0393\u03ba\u03c1\u03b1\u03bd\u03c4 \u0391\u03bd\u03c2"
     ],
+    "name:ell_x_variant":[
+        "\u0393\u03ba\u03c1\u03b1\u03bd\u03c4'\u0391\u03bd\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Grand' Anse"
     ],
@@ -89,6 +92,9 @@
         "Grand\u2019Anse",
         "D\u00e9partement de la Grand\u2019Anse",
         "Grand Anse"
+    ],
+    "name:frr_x_preferred":[
+        "Grand\u2019Anse"
     ],
     "name:guj_x_preferred":[
         "\u0a97\u0acd\u0ab0\u0abe\u0aa8\u0acd\u0aa1'\u0a8f\u0a82\u0ab8"
@@ -126,6 +132,9 @@
     "name:kor_x_preferred":[
         "\uadf8\ub791\ub2f9\uc2a4 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\uadf8\ub791\ub2f9\uc2a4\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Granansa"
     ],
@@ -137,6 +146,9 @@
     ],
     "name:msa_x_preferred":[
         "Grand'Anse"
+    ],
+    "name:nan_x_preferred":[
+        "Grand'Anse Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Grand'Anse"
@@ -194,6 +206,9 @@
     ],
     "name:vie_x_preferred":[
         "Grand'Anse"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d2\u10e0\u10d0\u10dc\u10d3-\u10d0\u10dc\u10e1\u10d8\u10e8 \u10d3\u10d4\u10de\u10d0\u10e0\u10e2\u10d0\u10db\u10d4\u10dc\u10e2\u10d8"
     ],
     "name:zho_x_preferred":[
         "\u5927\u7063\u7701"
@@ -321,7 +336,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1636495599,
+    "wof:lastmodified":1690930592,
     "wof:name":"Grand'Anse",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/37/85671937.geojson
+++ b/data/856/719/37/85671937.geojson
@@ -50,6 +50,9 @@
     "name:ell_x_preferred":[
         "\u039d\u03b9\u03c0\u03c2"
     ],
+    "name:ell_x_variant":[
+        "\u039d\u03b9\u03c0"
+    ],
     "name:eng_x_preferred":[
         "Nippes"
     ],
@@ -73,6 +76,9 @@
     ],
     "name:fra_x_variant":[
         "Grand 'Anse"
+    ],
+    "name:frr_x_preferred":[
+        "Nippes"
     ],
     "name:guj_x_preferred":[
         "\u0aa8\u0abf\u0aaa\u0acd\u0aaa\u0acd\u0ab8"
@@ -107,6 +113,9 @@
     "name:kor_x_preferred":[
         "\ub2c8\ud504 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ub2c8\ud504\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Nipesa"
     ],
@@ -118,6 +127,9 @@
     ],
     "name:msa_x_preferred":[
         "Nippes"
+    ],
+    "name:nan_x_preferred":[
+        "Nippes Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Nippes"
@@ -172,6 +184,9 @@
     ],
     "name:vie_x_preferred":[
         "Nippes"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10dc\u10d8\u10de\u10d8\u10e8 \u10d3\u10d4\u10de\u10d0\u10e0\u10e2\u10d0\u10db\u10d4\u10dc\u10e2\u10d8"
     ],
     "name:zho_x_preferred":[
         "\u5c3c\u666e\u65af\u7701"
@@ -301,7 +316,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1636495599,
+    "wof:lastmodified":1690930592,
     "wof:name":"Nippes",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/41/85671941.geojson
+++ b/data/856/719/41/85671941.geojson
@@ -50,6 +50,9 @@
     "name:ell_x_preferred":[
         "\u0392\u03bf\u03c1\u03b5\u03b9\u03bf\u03b4\u03c5\u03c4\u03b9\u03ba\u03cc \u0394\u03b9\u03b1\u03bc\u03ad\u03c1\u03b9\u03c3\u03bc\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u039d\u03bf\u03c1-\u039f\u03c5\u03ad\u03c3\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Nord-Ouest"
     ],
@@ -70,6 +73,9 @@
     ],
     "name:fra_x_unknown":[
         "NO"
+    ],
+    "name:frr_x_preferred":[
+        "Nord-Ouest"
     ],
     "name:guj_x_preferred":[
         "\u0aa8\u0acb\u0ab0\u0acd\u0aa1-\u0a95\u0acd\u0ab5\u0ac7\u0ab8\u0acd\u0a9f"
@@ -107,6 +113,9 @@
     "name:kor_x_preferred":[
         "\ubd81\uc11c\ubd80 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ubd81\uc11c\ubd80\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Zieme\u013crietumi"
     ],
@@ -118,6 +127,9 @@
     ],
     "name:msa_x_preferred":[
         "Nord-Ouest"
+    ],
+    "name:nan_x_preferred":[
+        "Nord-Ouest Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Nord-Ouest"
@@ -304,7 +316,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1636495600,
+    "wof:lastmodified":1690930593,
     "wof:name":"Nord-Ouest",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/47/85671947.geojson
+++ b/data/856/719/47/85671947.geojson
@@ -33,6 +33,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0625\u062f\u0627\u0631\u0629 \u0627\u0644\u062c\u0646\u0648\u0628\u064a\u0629"
     ],
+    "name:bel_x_preferred":[
+        "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u044b \u0434\u044d\u043f\u0430\u0440\u0442\u0430\u043c\u0435\u043d\u0442"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c1\u09a6"
     ],
@@ -48,8 +51,14 @@
     "name:deu_x_preferred":[
         "D\u00e9partement Sud"
     ],
+    "name:deu_x_variant":[
+        "Haiti-Sud"
+    ],
     "name:ell_x_preferred":[
         "\u03a3\u03bf\u03c5\u03bd\u03c4"
+    ],
+    "name:ell_x_variant":[
+        "\u03a3\u03c5\u03bd\u03c4"
     ],
     "name:eng_x_preferred":[
         "Sud"
@@ -74,6 +83,9 @@
     ],
     "name:fra_x_unknown":[
         "SD"
+    ],
+    "name:frr_x_preferred":[
+        "Sud"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac1\u0aa6"
@@ -126,6 +138,9 @@
     "name:msa_x_preferred":[
         "Sud"
     ],
+    "name:nan_x_preferred":[
+        "Sud Ko\u0101n"
+    ],
     "name:nld_x_preferred":[
         "Sud"
     ],
@@ -140,6 +155,9 @@
     ],
     "name:por_x_preferred":[
         "Departamento do Sul"
+    ],
+    "name:por_x_variant":[
+        "Sul"
     ],
     "name:rus_x_preferred":[
         "\u042e\u0436\u043d\u044b\u0439 \u0434\u0435\u043f\u0430\u0440\u0442\u0430\u043c\u0435\u043d\u0442"
@@ -309,7 +327,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1636495600,
+    "wof:lastmodified":1690930594,
     "wof:name":"Sud",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/49/85671949.geojson
+++ b/data/856/719/49/85671949.geojson
@@ -71,6 +71,9 @@
     "name:fra_x_unknown":[
         "ART"
     ],
+    "name:frr_x_preferred":[
+        "Artibonite"
+    ],
     "name:guj_x_preferred":[
         "\u0a86\u0ab0\u0acd\u0a9f\u0abf\u0aac\u0acb\u0aa8\u0abe\u0a88\u0a9f"
     ],
@@ -104,6 +107,9 @@
     "name:kor_x_preferred":[
         "\uc544\ub974\ud2f0\ubcf4\ub2c8\ud2b8 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\uc544\ub974\ud2f0\ubcf4\ub2c8\ud2b8\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Artibonita"
     ],
@@ -133,6 +139,9 @@
     ],
     "name:por_x_preferred":[
         "Artibonite"
+    ],
+    "name:por_x_variant":[
+        "Artibonita"
     ],
     "name:rus_x_preferred":[
         "\u0410\u0440\u0442\u0438\u0431\u043e\u043d\u0438\u0442"
@@ -175,6 +184,9 @@
     ],
     "name:vie_x_preferred":[
         "Artibonite"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d0\u10e0\u10e2\u10d8\u10d1\u10dd\u10dc\u10d8\u10e2\u10d8\u10e8 \u10d3\u10d4\u10de\u10d0\u10e0\u10e2\u10d0\u10db\u10d4\u10dc\u10e2\u10d8"
     ],
     "name:zho_x_preferred":[
         "\u963f\u8482\u535a\u5c3c\u7279\u7701"
@@ -304,7 +316,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1636495600,
+    "wof:lastmodified":1690930593,
     "wof:name":"L'Artibonite",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/55/85671955.geojson
+++ b/data/856/719/55/85671955.geojson
@@ -54,6 +54,9 @@
     "name:ell_x_preferred":[
         "\u039a\u03b5\u03bd\u03c4\u03c1\u03b9\u03ba\u03cc \u0394\u03b9\u03b1\u03bc\u03ad\u03c1\u03b9\u03c3\u03bc\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u03a3\u03b1\u03bd\u03c4\u03c1"
+    ],
     "name:eng_x_preferred":[
         "Centre"
     ],
@@ -77,6 +80,9 @@
     ],
     "name:fra_x_variant":[
         "centre"
+    ],
+    "name:frr_x_preferred":[
+        "Centre"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f\u0ab0"
@@ -128,6 +134,9 @@
     ],
     "name:msa_x_preferred":[
         "Centre"
+    ],
+    "name:nan_x_preferred":[
+        "Centre Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Centre"
@@ -182,6 +191,9 @@
     ],
     "name:vie_x_preferred":[
         "Centre"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10ea\u10d4\u10dc\u10e2\u10e0\u10d0\u10da\u10e3\u10e0\u10d8 \u10d3\u10d4\u10de\u10d0\u10e0\u10e2\u10d0\u10db\u10d4\u10dc\u10e2\u10d8"
     ],
     "name:zho_x_preferred":[
         "\u4e2d\u592e\u7701"
@@ -311,7 +323,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1636495599,
+    "wof:lastmodified":1690930593,
     "wof:name":"Centre",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/57/85671957.geojson
+++ b/data/856/719/57/85671957.geojson
@@ -48,6 +48,9 @@
     "name:ell_x_preferred":[
         "\u0392\u03bf\u03c1\u03b5\u03b9\u03bf\u03b1\u03bd\u03b1\u03c4\u03bf\u03bb\u03b9\u03ba\u03cc \u0394\u03b9\u03b1\u03bc\u03ad\u03c1\u03b9\u03c3\u03bc\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u039d\u03bf\u03c1-\u0395\u03c3\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Nord-Est"
     ],
@@ -68,6 +71,9 @@
     ],
     "name:fra_x_unknown":[
         "NE"
+    ],
+    "name:frr_x_preferred":[
+        "Nord-Est"
     ],
     "name:guj_x_preferred":[
         "\u0aa8\u0acb\u0ab0\u0acd\u0aa1-\u0a88\u0ab8\u0acd\u0a9f"
@@ -102,6 +108,9 @@
     "name:kor_x_preferred":[
         "\ubd81\ub3d9\ubd80 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ubd81\ub3d9\ubd80\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Zieme\u013caustrumi"
     ],
@@ -113,6 +122,9 @@
     ],
     "name:msa_x_preferred":[
         "Nord-Est"
+    ],
+    "name:nan_x_preferred":[
+        "Nord-Est Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Nord-Est"
@@ -299,7 +311,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1636495598,
+    "wof:lastmodified":1690930591,
     "wof:name":"Nord-Est",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/61/85671961.geojson
+++ b/data/856/719/61/85671961.geojson
@@ -48,8 +48,14 @@
     "name:deu_x_preferred":[
         "D\u00e9partement Nord"
     ],
+    "name:deu_x_variant":[
+        "Nord"
+    ],
     "name:ell_x_preferred":[
         "\u0392\u03cc\u03c1\u03b5\u03b9\u03bf \u0394\u03b9\u03b1\u03bc\u03ad\u03c1\u03b9\u03c3\u03bc\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u039d\u03bf\u03c1"
     ],
     "name:eng_x_preferred":[
         "Nord"
@@ -72,6 +78,9 @@
     "name:fra_x_unknown":[
         "ND"
     ],
+    "name:frr_x_preferred":[
+        "Nord"
+    ],
     "name:guj_x_preferred":[
         "\u0aa8\u0acb\u0ab0\u0acd\u0aa1"
     ],
@@ -86,6 +95,9 @@
     ],
     "name:hrv_x_preferred":[
         "Nord"
+    ],
+    "name:hye_x_preferred":[
+        "\u0546\u0578\u0580\u0564"
     ],
     "name:ind_x_preferred":[
         "Nord"
@@ -117,6 +129,9 @@
     "name:msa_x_preferred":[
         "Nord"
     ],
+    "name:nan_x_preferred":[
+        "Nord Ko\u0101n"
+    ],
     "name:nld_x_preferred":[
         "Nord"
     ],
@@ -126,11 +141,17 @@
     "name:nob_x_preferred":[
         "Nord"
     ],
+    "name:oci_x_preferred":[
+        "N\u00f2rd"
+    ],
     "name:pol_x_preferred":[
         "Departament P\u00f3\u0142nocny"
     ],
     "name:por_x_preferred":[
         "Departamento do Norte"
+    ],
+    "name:por_x_variant":[
+        "Norte"
     ],
     "name:rus_x_preferred":[
         "\u0421\u0435\u0432\u0435\u0440\u043d\u044b\u0439 \u0434\u0435\u043f\u0430\u0440\u0442\u0430\u043c\u0435\u043d\u0442 \u0413\u0430\u0438\u0442\u0438"
@@ -303,7 +324,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1636495598,
+    "wof:lastmodified":1690930590,
     "wof:name":"Nord",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/67/85671967.geojson
+++ b/data/856/719/67/85671967.geojson
@@ -42,14 +42,23 @@
     "name:cat_x_preferred":[
         "Ouest"
     ],
+    "name:ces_x_preferred":[
+        "Ouest"
+    ],
     "name:dan_x_preferred":[
         "Ouest"
     ],
     "name:deu_x_preferred":[
         "D\u00e9partement Ouest"
     ],
+    "name:deu_x_variant":[
+        "Ouest"
+    ],
     "name:ell_x_preferred":[
         "\u0394\u03c5\u03c4\u03b9\u03ba\u03cc \u0394\u03b9\u03b1\u03bc\u03ad\u03c1\u03b9\u03c3\u03bc\u03b1"
+    ],
+    "name:ell_x_variant":[
+        "\u039f\u03c5\u03ad\u03c3\u03c4"
     ],
     "name:eng_x_preferred":[
         "Ouest"
@@ -72,6 +81,9 @@
     "name:fra_x_unknown":[
         "OST"
     ],
+    "name:frr_x_preferred":[
+        "Ouest"
+    ],
     "name:guj_x_preferred":[
         "\u0a94\u0a8f\u0ab8\u0acd\u0a9f"
     ],
@@ -90,6 +102,9 @@
     "name:hun_x_preferred":[
         "Ouest"
     ],
+    "name:hye_x_preferred":[
+        "\u0554\u0578\u0582\u0565\u057d\u0569"
+    ],
     "name:ind_x_preferred":[
         "Ouest"
     ],
@@ -100,7 +115,8 @@
         "\u30a6\u30a7\u30b9\u30c8"
     ],
     "name:jpn_x_variant":[
-        "\u897f\u770c"
+        "\u897f\u770c",
+        "\u30a6\u30a8\u30b9\u30c8\u770c"
     ],
     "name:kan_x_preferred":[
         "\u0c93\u0caf\u0cc6\u0cb8\u0ccd\u0c9f\u0ccd"
@@ -123,6 +139,9 @@
     "name:msa_x_preferred":[
         "Ouest"
     ],
+    "name:nan_x_preferred":[
+        "Ouest Ko\u0101n"
+    ],
     "name:nld_x_preferred":[
         "Ouest"
     ],
@@ -132,11 +151,17 @@
     "name:nob_x_preferred":[
         "Ouest"
     ],
+    "name:oci_x_preferred":[
+        "O\u00e8st"
+    ],
     "name:pol_x_preferred":[
         "Departament Zachodni"
     ],
     "name:por_x_preferred":[
         "Departamento do Oeste"
+    ],
+    "name:por_x_variant":[
+        "Oeste"
     ],
     "name:rus_x_preferred":[
         "\u0417\u0430\u043f\u0430\u0434\u043d\u044b\u0439 \u0434\u0435\u043f\u0430\u0440\u0442\u0430\u043c\u0435\u043d\u0442 \u0413\u0430\u0438\u0442\u0438"
@@ -159,6 +184,9 @@
     "name:tel_x_preferred":[
         "\u0c13\u0c2f\u0c46\u0c38\u0c4d\u0c1f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0434\u0435\u043f\u0430\u0440\u0442\u0430\u043c\u0435\u043d\u0442\u0438 \u0492\u0430\u0440\u0431\u04e3"
+    ],
     "name:tha_x_preferred":[
         "\u0e40\u0e04\u0e27\u0e2a"
     ],
@@ -179,6 +207,9 @@
     ],
     "name:vie_x_preferred":[
         "Ouest"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10d1\u10df\u10d0\u10d3\u10d0\u10da\u10d8 \u10d3\u10d4\u10de\u10d0\u10e0\u10e2\u10d0\u10db\u10d4\u10dc\u10e2\u10d8"
     ],
     "name:zho_x_preferred":[
         "\u897f\u90e8\u7701"
@@ -306,7 +337,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1636495599,
+    "wof:lastmodified":1690930591,
     "wof:name":"Ouest",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/69/85671969.geojson
+++ b/data/856/719/69/85671969.geojson
@@ -42,6 +42,9 @@
     "name:ceb_x_preferred":[
         "Sud-Est"
     ],
+    "name:ces_x_preferred":[
+        "Sud-Est"
+    ],
     "name:dan_x_preferred":[
         "Sud-Est"
     ],
@@ -74,6 +77,9 @@
     ],
     "name:fra_x_unknown":[
         "SE"
+    ],
+    "name:frr_x_preferred":[
+        "Sud-Est"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac1\u0aa6-\u0a8f\u0ab8\u0acd\u0a9f"
@@ -111,6 +117,9 @@
     "name:kor_x_preferred":[
         "\ub0a8\ub3d9\ubd80 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ub0a8\ub3d9\ubd80\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Dienvidaustrumi"
     ],
@@ -122,6 +131,9 @@
     ],
     "name:msa_x_preferred":[
         "Sud-Est"
+    ],
+    "name:nan_x_preferred":[
+        "Sud-Est Ko\u0101n"
     ],
     "name:nld_x_preferred":[
         "Sud-Est"
@@ -140,6 +152,9 @@
     ],
     "name:rus_x_preferred":[
         "\u042e\u0433\u043e-\u0412\u043e\u0441\u0442\u043e\u0447\u043d\u044b\u0439 \u0434\u0435\u043f\u0430\u0440\u0442\u0430\u043c\u0435\u043d\u0442 \u0413\u0430\u0438\u0442\u0438"
+    ],
+    "name:rus_x_variant":[
+        "\u042e\u0433\u043e-\u0412\u043e\u0441\u0442\u043e\u0447\u043d\u044b\u0439 \u0434\u0435\u043f\u0430\u0440\u0442\u0430\u043c\u0435\u043d\u0442"
     ],
     "name:sin_x_preferred":[
         "\u0dc3\u0dd4\u0da9\u0dca-\u0d91\u0dc3\u0dca\u0da7\u0dca"
@@ -308,7 +323,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1636495598,
+    "wof:lastmodified":1690930591,
     "wof:name":"Sud-Est",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/890/422/935/890422935.geojson
+++ b/data/890/422/935/890422935.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u062a\u064a\u0631 \u0646\u0648\u0641"
     ],
+    "name:ceb_x_preferred":[
+        "Terre Neuve"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a4\u03b5\u03c1-\u039d\u03b5\u03b2"
+    ],
     "name:eng_x_preferred":[
         "Terre-Neuve"
     ],
@@ -32,6 +38,9 @@
         "T\u00e8n\u00e8v"
     ],
     "name:ita_x_preferred":[
+        "Terre-Neuve"
+    ],
+    "name:nan_x_preferred":[
         "Terre-Neuve"
     ],
     "name:nld_x_preferred":[
@@ -45,6 +54,9 @@
     ],
     "name:spa_x_preferred":[
         "Terre-Neuve"
+    ],
+    "name:swe_x_preferred":[
+        "Terre Neuve"
     ],
     "qs:name":"Terre Neuve",
     "qs:photos_9r":0,
@@ -79,7 +91,7 @@
         }
     ],
     "wof:id":890422935,
-    "wof:lastmodified":1566648901,
+    "wof:lastmodified":1690930610,
     "wof:name":"Terre Neuve",
     "wof:parent_id":1091686981,
     "wof:placetype":"locality",

--- a/data/890/430/973/890430973.geojson
+++ b/data/890/430/973/890430973.geojson
@@ -25,6 +25,12 @@
     "name:ceb_x_preferred":[
         "Arcahaie"
     ],
+    "name:deu_x_preferred":[
+        "Arcahaie"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03c1\u03ba\u03b1\u03b1\u03af"
+    ],
     "name:eng_x_preferred":[
         "Arcahaie"
     ],
@@ -37,10 +43,19 @@
     "name:ita_x_preferred":[
         "Arcahaie"
     ],
+    "name:jpn_x_preferred":[
+        "\u30e9\u30ab\u30a4\u30a8"
+    ],
+    "name:nan_x_preferred":[
+        "Arcahaie"
+    ],
     "name:nld_x_preferred":[
         "Arcahaie"
     ],
     "name:nob_x_preferred":[
+        "Arcahaie"
+    ],
+    "name:pol_x_preferred":[
         "Arcahaie"
     ],
     "name:por_x_preferred":[
@@ -49,10 +64,16 @@
     "name:ron_x_preferred":[
         "Arcahaie"
     ],
+    "name:rus_x_preferred":[
+        "\u0410\u0440\u043a\u0430\u0435"
+    ],
     "name:spa_x_preferred":[
         "Arcahaie"
     ],
     "name:swe_x_preferred":[
+        "Arcahaie"
+    ],
+    "name:szl_x_preferred":[
         "Arcahaie"
     ],
     "qs:name":"Arcahaie",
@@ -88,7 +109,7 @@
         }
     ],
     "wof:id":890430973,
-    "wof:lastmodified":1566648902,
+    "wof:lastmodified":1690930612,
     "wof:name":"Arcahaie",
     "wof:parent_id":1091686781,
     "wof:placetype":"locality",

--- a/data/890/430/977/890430977.geojson
+++ b/data/890/430/977/890430977.geojson
@@ -22,11 +22,17 @@
     "name:ara_x_preferred":[
         "\u0641\u064a\u0631\u064a\u0631"
     ],
+    "name:ben_x_preferred":[
+        "\u09ab\u09c7\u09b0\u09bf\u09af\u09bc\u09be\u09b0"
+    ],
     "name:ceb_x_preferred":[
         "Ferrier"
     ],
     "name:deu_x_preferred":[
         "Ferrier"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a6\u03b5\u03c1\u03b9\u03ad"
     ],
     "name:eng_x_preferred":[
         "Ferrier"
@@ -41,6 +47,12 @@
         "Ferye"
     ],
     "name:ita_x_preferred":[
+        "Ferrier"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d5\u30a7\u30ea\u30a8"
+    ],
+    "name:nan_x_preferred":[
         "Ferrier"
     ],
     "name:nld_x_preferred":[
@@ -94,7 +106,7 @@
         }
     ],
     "wof:id":890430977,
-    "wof:lastmodified":1566648902,
+    "wof:lastmodified":1690930611,
     "wof:name":"Ferrier",
     "wof:parent_id":1091686227,
     "wof:placetype":"locality",

--- a/data/890/430/979/890430979.geojson
+++ b/data/890/430/979/890430979.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u0625\u0646\u064a\u0631\u064a"
     ],
+    "name:cat_x_preferred":[
+        "Ennery"
+    ],
     "name:ceb_x_preferred":[
         "Ennery"
+    ],
+    "name:ell_x_preferred":[
+        "\u0395\u03bd\u03b5\u03c1\u03af"
     ],
     "name:eng_x_preferred":[
         "Ennery"
@@ -42,6 +48,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a8\u30cd\u30ea\u30fc"
+    ],
+    "name:nan_x_preferred":[
+        "Ennery"
     ],
     "name:nld_x_preferred":[
         "Ennery"
@@ -91,7 +100,7 @@
         }
     ],
     "wof:id":890430979,
-    "wof:lastmodified":1566648902,
+    "wof:lastmodified":1690930612,
     "wof:name":"Ennery",
     "wof:parent_id":1091687025,
     "wof:placetype":"locality",

--- a/data/890/430/983/890430983.geojson
+++ b/data/890/430/983/890430983.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Carice"
     ],
+    "name:ell_x_preferred":[
+        "\u039a\u03b1\u03c1\u03af\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Carice"
     ],
@@ -35,6 +38,12 @@
         "Karis"
     ],
     "name:ita_x_preferred":[
+        "Carice"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30ab\u30ea\u30b9"
+    ],
+    "name:nan_x_preferred":[
         "Carice"
     ],
     "name:nld_x_preferred":[
@@ -85,7 +94,7 @@
         }
     ],
     "wof:id":890430983,
-    "wof:lastmodified":1566648902,
+    "wof:lastmodified":1690930612,
     "wof:name":"Carice",
     "wof:parent_id":1091687119,
     "wof:placetype":"locality",

--- a/data/890/430/987/890430987.geojson
+++ b/data/890/430/987/890430987.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u064a \u062f\u064a \u0647\u0646\u064a"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03b1\u03b9-\u03bd\u03c4\u03b5-\u0395\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Baie-de-Henne"
     ],
@@ -32,6 +35,12 @@
         "Be de \u00c8n"
     ],
     "name:ita_x_preferred":[
+        "Baie-de-Henne"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d9\u30fb\u30c7\u30fb\u30d8\u30fc\u30cc"
+    ],
+    "name:nan_x_preferred":[
         "Baie-de-Henne"
     ],
     "name:nld_x_preferred":[
@@ -85,7 +94,7 @@
         }
     ],
     "wof:id":890430987,
-    "wof:lastmodified":1566648902,
+    "wof:lastmodified":1690930612,
     "wof:name":"Baie de Henne",
     "wof:parent_id":1091686921,
     "wof:placetype":"locality",

--- a/data/890/430/991/890430991.geojson
+++ b/data/890/430/991/890430991.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Abricots"
     ],
+    "name:ell_x_preferred":[
+        "\u0391\u03bc\u03c0\u03c1\u03b9\u03ba\u03cc"
+    ],
     "name:eng_x_preferred":[
         "Abricots"
     ],
@@ -43,6 +46,9 @@
     "name:jpn_x_preferred":[
         "\u30a2\u30d6\u30ea\u30b3"
     ],
+    "name:nan_x_preferred":[
+        "Abricots"
+    ],
     "name:nld_x_preferred":[
         "Abricots"
     ],
@@ -56,6 +62,9 @@
         "Los Albaricoques"
     ],
     "name:swe_x_preferred":[
+        "Abricots"
+    ],
+    "name:tur_x_preferred":[
         "Abricots"
     ],
     "name:und_x_variant":[
@@ -94,7 +103,7 @@
         }
     ],
     "wof:id":890430991,
-    "wof:lastmodified":1566648902,
+    "wof:lastmodified":1690930611,
     "wof:name":"Abricots",
     "wof:parent_id":1091686323,
     "wof:placetype":"locality",

--- a/data/890/432/565/890432565.geojson
+++ b/data/890/432/565/890432565.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u0645\u0628 \u0628\u064a\u0631\u0646"
     ],
+    "name:ceb_x_preferred":[
+        "Camp Perrin"
+    ],
+    "name:ell_x_preferred":[
+        "\u039a\u03b1\u03bd-\u03a0\u03b5\u03c1\u03ad\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Camp-Perrin"
     ],
@@ -37,6 +43,12 @@
     "name:ita_x_preferred":[
         "Camp-Perrin"
     ],
+    "name:jpn_x_preferred":[
+        "\u30ab\u30f3\u30da\u30e9\u30f3"
+    ],
+    "name:nan_x_preferred":[
+        "Camp-Perrin"
+    ],
     "name:nld_x_preferred":[
         "Camp-Perrin"
     ],
@@ -46,7 +58,16 @@
     "name:ron_x_preferred":[
         "Camp-Perrin"
     ],
+    "name:rus_x_preferred":[
+        "\u041a\u0430\u043c\u043f-\u041f\u0435\u0440\u0440\u0435\u043d"
+    ],
     "name:spa_x_preferred":[
+        "Camp-Perrin"
+    ],
+    "name:swe_x_preferred":[
+        "Camp Perrin"
+    ],
+    "name:szl_x_preferred":[
         "Camp-Perrin"
     ],
     "qs:name":"Camp Perrin",
@@ -82,7 +103,7 @@
         }
     ],
     "wof:id":890432565,
-    "wof:lastmodified":1566648905,
+    "wof:lastmodified":1690930618,
     "wof:name":"Camp Perrin",
     "wof:parent_id":1091686479,
     "wof:placetype":"locality",

--- a/data/890/435/443/890435443.geojson
+++ b/data/890/435/443/890435443.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0628\u064a\u062a\u064a\u062a \u062a\u0631\u0648 \u062f\u064a \u0646\u064a\u0628\u064a\u0633"
     ],
+    "name:ara_x_variant":[
+        "\u0628\u0648\u062a\u064a \u062a\u0631\u0648 \u062f\u0648 \u0646\u064a\u0628"
+    ],
     "name:cym_x_preferred":[
         "Petit-Trou-de-Nippes"
     ],
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":890435443,
-    "wof:lastmodified":1566648906,
+    "wof:lastmodified":1690930618,
     "wof:name":"Petit Trou de Nippes",
     "wof:parent_id":1091687241,
     "wof:placetype":"locality",

--- a/data/890/436/757/890436757.geojson
+++ b/data/890/436/757/890436757.geojson
@@ -31,6 +31,9 @@
     "name:fra_x_preferred":[
         "Fonds-Parisien"
     ],
+    "name:hat_x_preferred":[
+        "Fonparizyen"
+    ],
     "name:nld_x_preferred":[
         "Fonds-Parisien"
     ],
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":890436757,
-    "wof:lastmodified":1566648903,
+    "wof:lastmodified":1690930614,
     "wof:name":"Fond Parisien",
     "wof:parent_id":1091687379,
     "wof:placetype":"locality",

--- a/data/890/437/209/890437209.geojson
+++ b/data/890/437/209/890437209.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Pignon"
     ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03b9\u03bd\u03b9\u03cc\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Pignon"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30d4\u30cb\u30e7\u30f3"
+    ],
+    "name:nan_x_preferred":[
+        "Pignon"
     ],
     "name:nld_x_preferred":[
         "Pignon"
@@ -91,7 +97,7 @@
         }
     ],
     "wof:id":890437209,
-    "wof:lastmodified":1566648903,
+    "wof:lastmodified":1690930614,
     "wof:name":"Pignon",
     "wof:parent_id":1091686137,
     "wof:placetype":"locality",

--- a/data/890/437/211/890437211.geojson
+++ b/data/890/437/211/890437211.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Perches"
     ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03b5\u03c1\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Perches"
     ],
@@ -35,6 +38,12 @@
         "P\u00e8ch"
     ],
     "name:ita_x_preferred":[
+        "Perches"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30da\u30b7\u30e5"
+    ],
+    "name:nan_x_preferred":[
         "Perches"
     ],
     "name:nld_x_preferred":[
@@ -85,7 +94,7 @@
         }
     ],
     "wof:id":890437211,
-    "wof:lastmodified":1566648902,
+    "wof:lastmodified":1690930613,
     "wof:name":"Perches",
     "wof:parent_id":1091686227,
     "wof:placetype":"locality",

--- a/data/890/437/213/890437213.geojson
+++ b/data/890/437/213/890437213.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Moron"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03bf\u03c1\u03cc\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Moron"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30e2\u30a6\u30a9\u30f3"
+    ],
+    "name:nan_x_preferred":[
+        "Moron"
     ],
     "name:nld_x_preferred":[
         "Moron"
@@ -94,7 +100,7 @@
         }
     ],
     "wof:id":890437213,
-    "wof:lastmodified":1566648903,
+    "wof:lastmodified":1690930613,
     "wof:name":"Moron",
     "wof:parent_id":1091686323,
     "wof:placetype":"locality",

--- a/data/890/437/215/890437215.geojson
+++ b/data/890/437/215/890437215.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u0646\u062a \u0623\u0648\u0631\u063a\u064a\u0646\u064a\u0633"
     ],
+    "name:ceb_x_preferred":[
+        "Mont Organis\u00e9"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03bf\u03bd\u03c4-\u039f\u03c1\u03b3\u03ba\u03b1\u03bd\u03b9\u03b6\u03ad"
+    ],
     "name:eng_x_preferred":[
         "Mont-Organis\u00e9"
     ],
@@ -37,6 +43,12 @@
     "name:ita_x_preferred":[
         "Mont-Organis\u00e9"
     ],
+    "name:jpn_x_preferred":[
+        "\u30e2\u30f3\u30c8\u30fc\u30ac\u30cb\u30bc"
+    ],
+    "name:nan_x_preferred":[
+        "Mont-Organis\u00e9"
+    ],
     "name:nld_x_preferred":[
         "Mont-Organis\u00e9"
     ],
@@ -48,6 +60,9 @@
     ],
     "name:spa_x_preferred":[
         "Mont-Organis\u00e9"
+    ],
+    "name:swe_x_preferred":[
+        "Mont Organis\u00e9"
     ],
     "name:und_x_variant":[
         "Lassalle"
@@ -85,7 +100,7 @@
         }
     ],
     "wof:id":890437215,
-    "wof:lastmodified":1566648903,
+    "wof:lastmodified":1690930613,
     "wof:name":"Mont Organis\u00e9",
     "wof:parent_id":1091687117,
     "wof:placetype":"locality",

--- a/data/890/437/957/890437957.geojson
+++ b/data/890/437/957/890437957.geojson
@@ -22,6 +22,15 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u062a \u0631\u0627\u0641\u0627\u0626\u064a\u0644"
     ],
+    "name:ceb_x_preferred":[
+        "Saint- Rapha\u00ebl"
+    ],
+    "name:deu_x_preferred":[
+        "Saint-Rapha\u00ebl"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a3\u03b1\u03b9\u03bd-\u03a1\u03b1\u03c6\u03b1\u03ad\u03bb"
+    ],
     "name:eng_x_preferred":[
         "Saint-Rapha\u00ebl"
     ],
@@ -32,6 +41,9 @@
         "Sen Rafay\u00e8l"
     ],
     "name:ita_x_preferred":[
+        "Saint-Rapha\u00ebl"
+    ],
+    "name:nan_x_preferred":[
         "Saint-Rapha\u00ebl"
     ],
     "name:nld_x_preferred":[
@@ -45,6 +57,9 @@
     ],
     "name:spa_x_preferred":[
         "San Rafael"
+    ],
+    "name:swe_x_preferred":[
+        "Saint- Rapha\u00ebl"
     ],
     "name:urd_x_preferred":[
         "\u0633\u06cc\u0646-\u0631\u0627\u0641\u06cc\u0644\u060c \u06c1\u06cc\u0679\u06cc"
@@ -85,7 +100,7 @@
         }
     ],
     "wof:id":890437957,
-    "wof:lastmodified":1566648903,
+    "wof:lastmodified":1690930613,
     "wof:name":"Saint-Rapha\u00ebl",
     "wof:parent_id":1091686895,
     "wof:placetype":"locality",

--- a/data/890/437/961/890437961.geojson
+++ b/data/890/437/961/890437961.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u062a \u0644\u0648\u064a\u0633 \u0627\u0644\u062c\u0646\u0648\u0628\u064a\u0629"
     ],
+    "name:ceb_x_preferred":[
+        "Saint-Louis du Sud"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a3\u03b1\u03b9\u03bd-\u039b\u03bf\u03c5\u03af-\u03bd\u03c4\u03c5-\u03a3\u03c5\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Saint-Louis-du-Sud"
     ],
@@ -40,6 +46,9 @@
     "name:jpn_x_preferred":[
         "\u30b5\u30f3\uff1d\u30eb\u30a4\uff1d\u30c7\u30e5\uff1d\u30b7\u30e5\u30c9"
     ],
+    "name:nan_x_preferred":[
+        "Saint-Louis-du-Sud"
+    ],
     "name:nld_x_preferred":[
         "Saint-Louis-du-Sud"
     ],
@@ -51,6 +60,9 @@
     ],
     "name:spa_x_preferred":[
         "Saint-Louis-du-Sud"
+    ],
+    "name:swe_x_preferred":[
+        "Saint-Louis du"
     ],
     "name:und_x_variant":[
         "Saint Louis"
@@ -91,7 +103,7 @@
         }
     ],
     "wof:id":890437961,
-    "wof:lastmodified":1566648903,
+    "wof:lastmodified":1690930613,
     "wof:name":"Saint-Louis du Sud",
     "wof:parent_id":1091687293,
     "wof:placetype":"locality",

--- a/data/890/438/875/890438875.geojson
+++ b/data/890/438/875/890438875.geojson
@@ -28,6 +28,9 @@
     "name:deu_x_preferred":[
         "Marigot"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03b1\u03c1\u03b9\u03b3\u03ba\u03cc"
+    ],
     "name:eng_x_preferred":[
         "Marigot"
     ],
@@ -38,6 +41,12 @@
         "Marigo"
     ],
     "name:ita_x_preferred":[
+        "Marigot"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30df\u30e9\u30b4\u30fc"
+    ],
+    "name:nan_x_preferred":[
         "Marigot"
     ],
     "name:nld_x_preferred":[
@@ -54,6 +63,9 @@
     ],
     "name:swe_x_preferred":[
         "Marigot"
+    ],
+    "name:zho_x_preferred":[
+        "\u9a6c\u91cc\u6208\u7279"
     ],
     "qs:name":"Marigot",
     "qs:photos_9r":0,
@@ -88,7 +100,7 @@
         }
     ],
     "wof:id":890438875,
-    "wof:lastmodified":1566648904,
+    "wof:lastmodified":1690930614,
     "wof:name":"Marigot",
     "wof:parent_id":1091687171,
     "wof:placetype":"locality",

--- a/data/890/438/879/890438879.geojson
+++ b/data/890/438/879/890438879.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Les Irois"
     ],
+    "name:ell_x_preferred":[
+        "\u039b\u03b5\u03b6 \u0399\u03c1\u03bf\u03c5\u03ac"
+    ],
     "name:eng_x_preferred":[
         "Les Irois"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30ec\u30b8\u30ef"
+    ],
+    "name:nan_x_preferred":[
+        "Les Irois"
     ],
     "name:nld_x_preferred":[
         "Les Irois"
@@ -91,7 +97,7 @@
         }
     ],
     "wof:id":890438879,
-    "wof:lastmodified":1566648904,
+    "wof:lastmodified":1690930615,
     "wof:name":"Les Irois",
     "wof:parent_id":1091686011,
     "wof:placetype":"locality",

--- a/data/890/438/881/890438881.geojson
+++ b/data/890/438/881/890438881.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u064a\u0648\u063a\u0627\u0646"
     ],
+    "name:ast_x_preferred":[
+        "L\u00e9og\u00e2ne"
+    ],
     "name:ben_x_preferred":[
         "\u09b2\u09bf\u0993\u0997\u09c7\u09a8"
+    ],
+    "name:cat_x_preferred":[
+        "L\u00e9og\u00e2ne"
     ],
     "name:ceb_x_preferred":[
         "L\u00e9og\u00e2ne"
@@ -36,6 +42,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039b\u03b5\u03bf\u03b6\u03ac\u03bd"
+    ],
+    "name:ell_x_variant":[
+        "\u039b\u03b5\u03bf\u03b3\u03ba\u03ac\u03bd"
     ],
     "name:eng_x_preferred":[
         "L\u00e9og\u00e2ne"
@@ -84,6 +93,9 @@
     ],
     "name:msa_x_preferred":[
         "Leogane"
+    ],
+    "name:nan_x_preferred":[
+        "L\u00e9og\u00e2ne"
     ],
     "name:nld_x_preferred":[
         "L\u00e9og\u00e2ne"
@@ -177,7 +189,7 @@
         }
     ],
     "wof:id":890438881,
-    "wof:lastmodified":1566648903,
+    "wof:lastmodified":1690930614,
     "wof:name":"L\u00e9og\u00e2ne",
     "wof:parent_id":1091687199,
     "wof:placetype":"locality",

--- a/data/890/438/883/890438883.geojson
+++ b/data/890/438/883/890438883.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Lazil"
     ],
+    "name:ell_x_preferred":[
+        "\u039b'\u0391\u03b6\u03af\u03bb"
+    ],
     "name:eng_x_preferred":[
         "L'Asile"
     ],
@@ -35,6 +38,9 @@
         "Lazil"
     ],
     "name:ita_x_preferred":[
+        "L'Asile"
+    ],
+    "name:nan_x_preferred":[
         "L'Asile"
     ],
     "name:nld_x_preferred":[
@@ -91,7 +97,7 @@
         }
     ],
     "wof:id":890438883,
-    "wof:lastmodified":1566648904,
+    "wof:lastmodified":1690930615,
     "wof:name":"L\u2019Asile",
     "wof:parent_id":1091687241,
     "wof:placetype":"locality",

--- a/data/890/438/885/890438885.geojson
+++ b/data/890/438/885/890438885.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u062c\u0631\u0648\u0633 \u0645\u0648\u0631\u0646"
     ],
+    "name:ceb_x_preferred":[
+        "Gros Morne"
+    ],
+    "name:ell_x_preferred":[
+        "\u0393\u03ba\u03c1\u03bf-\u039c\u03bf\u03c1\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Gros-Morne"
     ],
@@ -37,7 +43,13 @@
     "name:ita_x_preferred":[
         "Gros-Morne"
     ],
+    "name:nan_x_preferred":[
+        "Gros-Morne"
+    ],
     "name:nld_x_preferred":[
+        "Gros-Morne"
+    ],
+    "name:pol_x_preferred":[
         "Gros-Morne"
     ],
     "name:por_x_preferred":[
@@ -51,6 +63,9 @@
     ],
     "name:spa_x_preferred":[
         "Gros-Morne"
+    ],
+    "name:swe_x_preferred":[
+        "Gros Morne"
     ],
     "name:tur_x_preferred":[
         "Gros Morne"
@@ -100,7 +115,7 @@
         }
     ],
     "wof:id":890438885,
-    "wof:lastmodified":1636495611,
+    "wof:lastmodified":1690930615,
     "wof:name":"Gros Morne",
     "wof:parent_id":1091686981,
     "wof:placetype":"locality",

--- a/data/890/438/887/890438887.geojson
+++ b/data/890/438/887/890438887.geojson
@@ -25,6 +25,12 @@
     "name:ceb_x_preferred":[
         "Grangwav"
     ],
+    "name:deu_x_preferred":[
+        "Grand-Go\u00e2ve"
+    ],
+    "name:ell_x_preferred":[
+        "\u0393\u03ba\u03c1\u03b1\u03bd-\u0393\u03ba\u03bf\u03ac\u03b2"
+    ],
     "name:eng_x_preferred":[
         "Grand-Go\u00e2ve"
     ],
@@ -36,6 +42,12 @@
     ],
     "name:ita_x_preferred":[
         "Grand-G\u00f4ave"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b0\u30e9\u30f3\u30b4\u30a2\u30fc\u30f4"
+    ],
+    "name:nan_x_preferred":[
+        "Grand-Go\u00e2ve"
     ],
     "name:nld_x_preferred":[
         "Grand-Go\u00e2ve"
@@ -51,6 +63,9 @@
     ],
     "name:ron_x_preferred":[
         "Grand-Go\u00e2ve"
+    ],
+    "name:rus_x_preferred":[
+        "\u0413\u0440\u0430\u043d-\u0413\u043e\u0430\u0432"
     ],
     "name:spa_x_preferred":[
         "Grand-Go\u00e2ve"
@@ -100,7 +115,7 @@
         }
     ],
     "wof:id":890438887,
-    "wof:lastmodified":1566648903,
+    "wof:lastmodified":1690930614,
     "wof:name":"Grand Go\u00e2ve",
     "wof:parent_id":1091687199,
     "wof:placetype":"locality",

--- a/data/890/441/583/890441583.geojson
+++ b/data/890/441/583/890441583.geojson
@@ -31,6 +31,9 @@
     "name:deu_x_preferred":[
         "Verrettes"
     ],
+    "name:ell_x_preferred":[
+        "\u0392\u03b5\u03c1\u03ad\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Verrettes"
     ],
@@ -48,6 +51,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubca0\ub808\ud2b8"
+    ],
+    "name:nan_x_preferred":[
+        "Verrettes"
     ],
     "name:nld_x_preferred":[
         "Verrettes"
@@ -69,6 +75,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0412\u0435\u0440\u0435\u0442\u0442"
+    ],
+    "name:rus_x_variant":[
+        "\u0412\u0435\u0440\u0440\u0435\u0442"
     ],
     "name:spa_x_preferred":[
         "Verrettes"
@@ -121,7 +130,7 @@
         }
     ],
     "wof:id":890441583,
-    "wof:lastmodified":1566648901,
+    "wof:lastmodified":1690930611,
     "wof:name":"Verrettes",
     "wof:parent_id":1091686855,
     "wof:placetype":"locality",

--- a/data/890/441/967/890441967.geojson
+++ b/data/890/441/967/890441967.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Caracol"
     ],
+    "name:ell_x_preferred":[
+        "\u039a\u03b1\u03c1\u03b1\u03ba\u03cc\u03bb"
+    ],
     "name:eng_x_preferred":[
         "Caracol"
     ],
@@ -35,6 +38,12 @@
         "Karak\u00f2l"
     ],
     "name:ita_x_preferred":[
+        "Caracol"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30ab\u30e9\u30b3\u30eb"
+    ],
+    "name:nan_x_preferred":[
         "Caracol"
     ],
     "name:nld_x_preferred":[
@@ -51,6 +60,9 @@
     ],
     "name:swe_x_preferred":[
         "Caracol"
+    ],
+    "name:zho_x_preferred":[
+        "\u5361\u62c9\u79d1\u723e"
     ],
     "qs:name":"Caracol",
     "qs:photos_9r":0,
@@ -87,7 +99,7 @@
         }
     ],
     "wof:id":890441967,
-    "wof:lastmodified":1566648901,
+    "wof:lastmodified":1690930610,
     "wof:name":"Caracol",
     "wof:parent_id":1091687099,
     "wof:placetype":"locality",

--- a/data/890/441/969/890441969.geojson
+++ b/data/890/441/969/890441969.geojson
@@ -22,14 +22,23 @@
     "name:ara_x_preferred":[
         "\u0643\u0628\u0627\u0631\u064a\u0647"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0628\u0627\u0631\u064a\u0647"
+    ],
     "name:ast_x_preferred":[
         "Cabar\u00e9"
+    ],
+    "name:aze_x_preferred":[
+        "Kabare"
     ],
     "name:bar_x_preferred":[
         "Kabarett"
     ],
     "name:bel_x_preferred":[
         "\u041a\u0430\u0431\u0430\u0440\u044d"
+    ],
+    "name:ben_x_preferred":[
+        "\u0995\u09cd\u09af\u09be\u09ac\u09be\u09b0\u09c7"
     ],
     "name:bre_x_preferred":[
         "Kabarett"
@@ -39,6 +48,9 @@
     ],
     "name:cat_x_preferred":[
         "Cabaret"
+    ],
+    "name:cat_x_variant":[
+        "cabaret"
     ],
     "name:ces_x_preferred":[
         "kabaret"
@@ -76,6 +88,9 @@
     "name:fin_x_preferred":[
         "Kabaree"
     ],
+    "name:fin_x_variant":[
+        "kabaree"
+    ],
     "name:fra_x_preferred":[
         "cabaret"
     ],
@@ -112,6 +127,9 @@
     "name:kat_x_preferred":[
         "\u10d9\u10d0\u10d1\u10d0\u10e0\u10d4"
     ],
+    "name:kaz_x_preferred":[
+        "\u041a\u0430\u0431\u0430\u0440\u0435"
+    ],
     "name:kor_x_preferred":[
         "\uce74\ubc14\ub808"
     ],
@@ -142,6 +160,9 @@
     "name:nld_x_preferred":[
         "cabaret"
     ],
+    "name:nld_x_variant":[
+        "cabarettheater"
+    ],
     "name:nno_x_preferred":[
         "kabaret"
     ],
@@ -150,6 +171,9 @@
     ],
     "name:pan_x_preferred":[
         "\u0a15\u0a48\u0a2c\u0a30\u0a47"
+    ],
+    "name:pap_x_preferred":[
+        "kabar\u00e8t"
     ],
     "name:pcd_x_preferred":[
         "Cabaret"
@@ -187,6 +211,9 @@
     "name:swe_x_preferred":[
         "Kabar\u00e9"
     ],
+    "name:swe_x_variant":[
+        "kabar\u00e9"
+    ],
     "name:tha_x_preferred":[
         "\u0e04\u0e32\u0e1a\u0e32\u0e40\u0e23\u0e15\u0e4c"
     ],
@@ -199,8 +226,17 @@
     "name:und_x_variant":[
         "Duvalierville"
     ],
+    "name:urd_x_preferred":[
+        "\u06a9\u06cc\u0628\u0631\u06d2"
+    ],
     "name:vie_x_preferred":[
         "Cabaret"
+    ],
+    "name:vie_x_variant":[
+        "cabaret"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5361\u5df4\u83b1"
     ],
     "name:zho_x_preferred":[
         "\u5361\u5df4\u840a"
@@ -238,7 +274,7 @@
         }
     ],
     "wof:id":890441969,
-    "wof:lastmodified":1566648901,
+    "wof:lastmodified":1690930611,
     "wof:name":"Cabaret",
     "wof:parent_id":1091686327,
     "wof:placetype":"locality",

--- a/data/890/445/083/890445083.geojson
+++ b/data/890/445/083/890445083.geojson
@@ -22,10 +22,28 @@
     "name:ara_x_preferred":[
         "\u062a\u0631\u0648 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629"
     ],
+    "name:aze_x_preferred":[
+        "Tru-dyu-Nor"
+    ],
+    "name:cat_x_preferred":[
+        "Trou-du-Nord"
+    ],
+    "name:ceb_x_preferred":[
+        "Trou du Nord"
+    ],
+    "name:dan_x_preferred":[
+        "Trou-du-Nord"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a4\u03c1\u03bf\u03c5-\u03bd\u03c4\u03c5-\u039d\u03bf\u03c1"
+    ],
     "name:eng_x_preferred":[
         "Trou-du-Nord"
     ],
     "name:fra_x_preferred":[
+        "Trou-du-Nord"
+    ],
+    "name:gle_x_preferred":[
         "Trou-du-Nord"
     ],
     "name:hat_x_preferred":[
@@ -34,7 +52,19 @@
     "name:hat_x_variant":[
         "Twou din\u00f2"
     ],
+    "name:heb_x_preferred":[
+        "\u05d8\u05e8\u05d5-\u05d3\u05d9-\u05e0\u05d5\u05e8"
+    ],
     "name:ita_x_preferred":[
+        "Trou-du-Nord"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30c8\u30a5\u30eb\u30fb\u30c7\u30e5\u30fb\u30ce\u30fc\u30eb"
+    ],
+    "name:ltz_x_preferred":[
+        "Trou-du-Nord"
+    ],
+    "name:nan_x_preferred":[
         "Trou-du-Nord"
     ],
     "name:nld_x_preferred":[
@@ -54,6 +84,15 @@
     ],
     "name:spa_x_preferred":[
         "Trou-du-Nord"
+    ],
+    "name:swe_x_preferred":[
+        "Trou du Nord"
+    ],
+    "name:szl_x_preferred":[
+        "Trou-du-Nord"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0422\u0440\u0443-\u0434\u044e-\u041d\u043e\u0440\u0434"
     ],
     "name:und_x_variant":[
         "Le Trou"
@@ -94,7 +133,7 @@
         }
     ],
     "wof:id":890445083,
-    "wof:lastmodified":1566648904,
+    "wof:lastmodified":1690930615,
     "wof:name":"Trou du Nord",
     "wof:parent_id":1091687099,
     "wof:placetype":"locality",

--- a/data/890/445/085/890445085.geojson
+++ b/data/890/445/085/890445085.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646 \u0645\u0627\u0631\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646 \u0645\u0627\u0631\u0643"
+    ],
+    "name:ast_x_preferred":[
+        "Saint-Marc"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f-\u09ae\u09be\u09b0\u09cd\u0995"
     ],
@@ -37,6 +43,9 @@
     "name:ell_x_preferred":[
         "\u03a3\u03b1\u03bd \u039c\u03b1\u03c1\u03ba"
     ],
+    "name:ell_x_variant":[
+        "\u03a3\u03b1\u03b9\u03bd-\u039c\u03b1\u03c1\u03ba"
+    ],
     "name:eng_x_preferred":[
         "Saint-Marc"
     ],
@@ -46,14 +55,23 @@
     "name:fra_x_preferred":[
         "Saint-Marc"
     ],
+    "name:gle_x_preferred":[
+        "Saint-Marc"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0a82\u0a9f-\u0aae\u0abe\u0ab0\u0acd\u0a95"
     ],
     "name:hat_x_preferred":[
         "Sen Mak"
     ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05e0\u05d8 \u05de\u05e8\u05e7"
+    ],
     "name:hin_x_preferred":[
         "\u0938\u0947\u0902\u091f \u092e\u093e\u0930\u094d\u0915"
+    ],
+    "name:hun_x_preferred":[
+        "Saint-Marc"
     ],
     "name:ind_x_preferred":[
         "Saint-Marc"
@@ -80,6 +98,9 @@
         "\u0938\u0947\u0902\u091f-\u092e\u093e\u0930\u094d\u0915"
     ],
     "name:msa_x_preferred":[
+        "Saint-Marc"
+    ],
+    "name:nan_x_preferred":[
         "Saint-Marc"
     ],
     "name:nld_x_preferred":[
@@ -130,6 +151,9 @@
     "name:urd_x_preferred":[
         "\u0633\u06cc\u0646\u0679-\u0645\u0627\u0631\u06a9"
     ],
+    "name:vec_x_preferred":[
+        "Saint-Marc"
+    ],
     "name:vie_x_preferred":[
         "Saint-Marc"
     ],
@@ -172,7 +196,7 @@
         }
     ],
     "wof:id":890445085,
-    "wof:lastmodified":1566648905,
+    "wof:lastmodified":1690930616,
     "wof:name":"Saint-Marc",
     "wof:parent_id":1091686855,
     "wof:placetype":"locality",

--- a/data/890/445/091/890445091.geojson
+++ b/data/890/445/091/890445091.geojson
@@ -25,7 +25,13 @@
     "name:ben_x_preferred":[
         "\u099c\u09cd\u09af\u09be\u0995\u09ae\u09c7\u09b2"
     ],
+    "name:cat_x_preferred":[
+        "Jacmel"
+    ],
     "name:ceb_x_preferred":[
+        "Jacmel"
+    ],
+    "name:ces_x_preferred":[
         "Jacmel"
     ],
     "name:che_x_preferred":[
@@ -73,6 +79,9 @@
     "name:hun_x_preferred":[
         "Jacmel"
     ],
+    "name:hye_x_preferred":[
+        "\u053a\u0561\u056f\u0574\u0565\u056c"
+    ],
     "name:ind_x_preferred":[
         "Jacmel"
     ],
@@ -101,6 +110,9 @@
         "\u091c\u0945\u0915\u092e\u0947\u0932"
     ],
     "name:msa_x_preferred":[
+        "Jacmel"
+    ],
+    "name:nan_x_preferred":[
         "Jacmel"
     ],
     "name:nld_x_preferred":[
@@ -136,6 +148,9 @@
     "name:sin_x_preferred":[
         "\u0da2\u0dd0\u0d9a\u0dca\u0db8\u0dda\u0dbd\u0dca"
     ],
+    "name:slk_x_preferred":[
+        "Jacmel"
+    ],
     "name:spa_x_preferred":[
         "Y\u00e1quimo"
     ],
@@ -168,6 +183,9 @@
     ],
     "name:vie_x_preferred":[
         "Jacmel"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10df\u10d0\u10d9\u10db\u10d4\u10da\u10d8"
     ],
     "name:zho_x_preferred":[
         "\u96c5\u514b\u6885\u52d2"
@@ -308,7 +326,7 @@
         }
     ],
     "wof:id":890445091,
-    "wof:lastmodified":1636495612,
+    "wof:lastmodified":1690930616,
     "wof:name":"Jacmel",
     "wof:parent_id":1091687171,
     "wof:placetype":"locality",

--- a/data/890/445/093/890445093.geojson
+++ b/data/890/445/093/890445093.geojson
@@ -37,6 +37,9 @@
     "name:ell_x_preferred":[
         "\u03a7\u03af\u03bd\u03c4\u03c3\u03b5"
     ],
+    "name:ell_x_variant":[
+        "\u0395\u03bd\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Hinche"
     ],
@@ -57,6 +60,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05d4\u05d9\u05e0\u05e6'\u05d4"
+    ],
+    "name:heb_x_variant":[
+        "\u05d4\u05d9\u05e0\u05e9"
     ],
     "name:hin_x_preferred":[
         "\u0939\u093f\u0902\u091a"
@@ -89,6 +95,9 @@
         "\u0939\u093f\u0902\u091a"
     ],
     "name:msa_x_preferred":[
+        "Hinche"
+    ],
+    "name:nan_x_preferred":[
         "Hinche"
     ],
     "name:nld_x_preferred":[
@@ -284,7 +293,7 @@
         }
     ],
     "wof:id":890445093,
-    "wof:lastmodified":1636495612,
+    "wof:lastmodified":1690930617,
     "wof:name":"Hinche",
     "wof:parent_id":1091686313,
     "wof:placetype":"locality",

--- a/data/890/445/095/890445095.geojson
+++ b/data/890/445/095/890445095.geojson
@@ -22,10 +22,22 @@
     "name:ara_x_preferred":[
         "\u0644\u064a\u0633 \u0643\u0627\u064a\u0633"
     ],
+    "name:ast_x_preferred":[
+        "Les Cayes"
+    ],
+    "name:aze_x_preferred":[
+        "Le-ke"
+    ],
     "name:ben_x_preferred":[
         "\u09b2\u09c7\u09b8 \u0995\u09be\u09af\u09bc\u09c7\u09b8"
     ],
+    "name:cat_x_preferred":[
+        "Les Cayes"
+    ],
     "name:ceb_x_preferred":[
+        "Les Cayes"
+    ],
+    "name:ces_x_preferred":[
         "Les Cayes"
     ],
     "name:dan_x_preferred":[
@@ -36,6 +48,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039b\u03b5 \u039a\u03b1\u03b0"
+    ],
+    "name:ell_x_variant":[
+        "\u039b\u03b5 \u039a\u03ac\u03b9\u03b3"
     ],
     "name:eng_x_preferred":[
         "Les Cayes"
@@ -50,6 +65,9 @@
         "Les Cayes"
     ],
     "name:fra_x_preferred":[
+        "Les Cayes"
+    ],
+    "name:gle_x_preferred":[
         "Les Cayes"
     ],
     "name:guj_x_preferred":[
@@ -82,6 +100,9 @@
     "name:kan_x_preferred":[
         "\u0cb2\u0cc6\u0cb8\u0ccd \u0c95\u0cc7\u0caf\u0ccd\u0cb8\u0ccd"
     ],
+    "name:kat_x_preferred":[
+        "\u10da\u10d4-\u10d9\u10d4"
+    ],
     "name:kor_x_preferred":[
         "\ub974\uce74\uc608"
     ],
@@ -95,6 +116,9 @@
         "\u0932\u0947\u0938 \u0915\u093e\u092f\u0947\u0938"
     ],
     "name:msa_x_preferred":[
+        "Les Cayes"
+    ],
+    "name:nan_x_preferred":[
         "Les Cayes"
     ],
     "name:nld_x_preferred":[
@@ -150,6 +174,9 @@
     ],
     "name:vie_x_preferred":[
         "Les Cayes"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10da\u10d4-\u10d9\u10d4"
     ],
     "name:zho_x_preferred":[
         "\u840a\u51f1"
@@ -281,7 +308,7 @@
         }
     ],
     "wof:id":890445095,
-    "wof:lastmodified":1636495612,
+    "wof:lastmodified":1690930617,
     "wof:name":"Les Cayes",
     "wof:parent_id":1091686479,
     "wof:placetype":"locality",

--- a/data/890/445/097/890445097.geojson
+++ b/data/890/445/097/890445097.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "C\u00f4tes-de-Fer"
     ],
+    "name:ell_x_preferred":[
+        "\u039a\u03bf\u03c4-\u03bd\u03c4\u03b5-\u03a6\u03b5\u03c1"
+    ],
     "name:eng_x_preferred":[
         "C\u00f4tes-de-Fer"
     ],
@@ -42,6 +45,12 @@
     ],
     "name:ita_x_preferred":[
         "C\u00f4te-de-Fer"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b3\u30fc\u30c8\u30fb\u30c7\u30d5\u30a7"
+    ],
+    "name:nan_x_preferred":[
+        "C\u00f4tes-de-Fer"
     ],
     "name:nld_x_preferred":[
         "C\u00f4tes-de-Fer"
@@ -97,7 +106,7 @@
         }
     ],
     "wof:id":890445097,
-    "wof:lastmodified":1566648905,
+    "wof:lastmodified":1690930616,
     "wof:name":"C\u00f4tes-de-Fer",
     "wof:parent_id":1091686057,
     "wof:placetype":"locality",

--- a/data/890/445/099/890445099.geojson
+++ b/data/890/445/099/890445099.geojson
@@ -22,6 +22,15 @@
     "name:ara_x_preferred":[
         "\u0643\u0648\u0631\u064a\u0644"
     ],
+    "name:cat_x_preferred":[
+        "Corail"
+    ],
+    "name:ceb_x_preferred":[
+        "Corail"
+    ],
+    "name:ell_x_preferred":[
+        "\u039a\u03bf\u03c1\u03ac\u03b9\u03b3"
+    ],
     "name:eng_x_preferred":[
         "Corail"
     ],
@@ -37,6 +46,9 @@
     "name:ita_x_preferred":[
         "Corail"
     ],
+    "name:nan_x_preferred":[
+        "Corail"
+    ],
     "name:nld_x_preferred":[
         "Corail"
     ],
@@ -50,6 +62,9 @@
         "\u041a\u043e\u0440\u0430\u0439"
     ],
     "name:spa_x_preferred":[
+        "Corail"
+    ],
+    "name:swe_x_preferred":[
         "Corail"
     ],
     "qs:name":"Corail",
@@ -85,7 +100,7 @@
         }
     ],
     "wof:id":890445099,
-    "wof:lastmodified":1566648905,
+    "wof:lastmodified":1690930616,
     "wof:name":"Corail",
     "wof:parent_id":1091686181,
     "wof:placetype":"locality",

--- a/data/890/445/101/890445101.geojson
+++ b/data/890/445/101/890445101.geojson
@@ -28,6 +28,9 @@
     "name:deu_x_preferred":[
         "Chambellan"
     ],
+    "name:ell_x_preferred":[
+        "\u03a3\u03b1\u03bc\u03c0\u03b5\u03bb\u03ac\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Chambellan"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30b7\u30e3\u30f3\u30d9\u30e9\u30f3"
+    ],
+    "name:nan_x_preferred":[
+        "Chambellan"
     ],
     "name:nld_x_preferred":[
         "Chambellan"
@@ -91,7 +97,7 @@
         }
     ],
     "wof:id":890445101,
-    "wof:lastmodified":1566648905,
+    "wof:lastmodified":1690930617,
     "wof:name":"Chambellan",
     "wof:parent_id":1091686323,
     "wof:placetype":"locality",

--- a/data/890/445/103/890445103.geojson
+++ b/data/890/445/103/890445103.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0627\u064a\u0633 \u062c\u0627\u0643\u0645\u064a\u0644"
     ],
+    "name:ell_x_preferred":[
+        "\u039a\u03ac\u03b9\u03b3-\u0396\u03b1\u03ba\u03bc\u03ad\u03bb"
+    ],
     "name:eng_x_preferred":[
         "Cayes-Jacmel"
     ],
@@ -32,6 +35,12 @@
         "Kay Jakm\u00e8l"
     ],
     "name:ita_x_preferred":[
+        "Cayes-Jacmel"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30ab\u30a4\u30fb\u30b8\u30e3\u30af\u30e1\u30eb"
+    ],
+    "name:nan_x_preferred":[
         "Cayes-Jacmel"
     ],
     "name:nld_x_preferred":[
@@ -45,6 +54,9 @@
     ],
     "name:spa_x_preferred":[
         "Cayes-Jacmel"
+    ],
+    "name:swe_x_preferred":[
+        "Cayes Jacmel"
     ],
     "name:und_x_variant":[
         "Cayes de Jacmel"
@@ -82,7 +94,7 @@
         }
     ],
     "wof:id":890445103,
-    "wof:lastmodified":1566648904,
+    "wof:lastmodified":1690930615,
     "wof:name":"Cayes Jacmel",
     "wof:parent_id":1091687171,
     "wof:placetype":"locality",

--- a/data/890/445/107/890445107.geojson
+++ b/data/890/445/107/890445107.geojson
@@ -105,6 +105,12 @@
     "name:nld_x_preferred":[
         "Carrefour"
     ],
+    "name:nno_x_preferred":[
+        "Carrefour"
+    ],
+    "name:nob_x_preferred":[
+        "Carrefour"
+    ],
     "name:pol_x_preferred":[
         "Carrefour"
     ],
@@ -117,7 +123,13 @@
     "name:rus_x_preferred":[
         "Carrefour"
     ],
+    "name:sgs_x_preferred":[
+        "Carrefour"
+    ],
     "name:slk_x_preferred":[
+        "Carrefour"
+    ],
+    "name:slv_x_preferred":[
         "Carrefour"
     ],
     "name:spa_x_preferred":[
@@ -133,6 +145,9 @@
         "Carrefour"
     ],
     "name:ukr_x_preferred":[
+        "Carrefour"
+    ],
+    "name:vec_x_preferred":[
         "Carrefour"
     ],
     "name:vie_x_preferred":[
@@ -179,7 +194,7 @@
         }
     ],
     "wof:id":890445107,
-    "wof:lastmodified":1566648905,
+    "wof:lastmodified":1690930617,
     "wof:name":"Carrefour",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.