### PR TITLE
ht concordances, placetype local, and more

### DIFF
--- a/data/109/168/601/1/1091686011.geojson
+++ b/data/109/168/601/1/1091686011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027829,
-    "geom:area_square_m":326391796.707879,
+    "geom:area_square_m":326391696.69764,
     "geom:bbox":"-74.4804,18.356304,-74.293419,18.642911",
     "geom:latitude":18.466287,
     "geom:longitude":-74.391,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.GR.AH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879155,
-    "wof:geomhash":"21afb733a33be7298f62435678102451",
+    "wof:geomhash":"fe4548a1d974d70e8c37e9479ee44c6c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091686011,
-    "wof:lastmodified":1627522190,
+    "wof:lastmodified":1695886669,
     "wof:name":"Anse d'Hainault",
     "wof:parent_id":85671933,
     "wof:placetype":"county",

--- a/data/109/168/605/7/1091686057.geojson
+++ b/data/109/168/605/7/1091686057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04778,
-    "geom:area_square_m":561150184.523267,
+    "geom:area_square_m":561150184.523474,
     "geom:bbox":"-73.0155786329,18.141887237,-72.629268365,18.3293846272",
     "geom:latitude":18.230376,
     "geom:longitude":-72.821109,
@@ -98,9 +98,10 @@
     "wof:concordances":{
         "hasc:id":"HT.SE.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879157,
-    "wof:geomhash":"0d1243714277ff73e487e33dbd019831",
+    "wof:geomhash":"4c5fae94464d8f713c34728320a28a6b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091686057,
-    "wof:lastmodified":1566648833,
+    "wof:lastmodified":1695886419,
     "wof:name":"Bainet",
     "wof:parent_id":85671969,
     "wof:placetype":"county",

--- a/data/109/168/610/7/1091686107.geojson
+++ b/data/109/168/610/7/1091686107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065447,
-    "geom:area_square_m":768612251.241904,
+    "geom:area_square_m":768612251.241492,
     "geom:bbox":"-72.247597271,18.031697572,-71.7269325367,18.3536983888",
     "geom:latitude":18.237354,
     "geom:longitude":-71.958908,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"HT.SE.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879158,
-    "wof:geomhash":"c9c06c8fac5e9777dfd61e7aafead326",
+    "wof:geomhash":"61a0f05642c3f43a9bbebd91013809c9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1091686107,
-    "wof:lastmodified":1566648831,
+    "wof:lastmodified":1695886419,
     "wof:name":"Belle-Anse",
     "wof:parent_id":85671969,
     "wof:placetype":"county",

--- a/data/109/168/613/7/1091686137.geojson
+++ b/data/109/168/613/7/1091686137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048418,
-    "geom:area_square_m":564052896.151217,
+    "geom:area_square_m":564052896.151122,
     "geom:bbox":"-72.6826347981,19.2554511844,-71.9737619075,19.8816824686",
     "geom:latitude":19.587273,
     "geom:longitude":-72.326226,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"HT.ND.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879160,
-    "wof:geomhash":"8ff94c5e391b35c1c3c1122414bc1d52",
+    "wof:geomhash":"89abb30b2ce2ccab46840ec08379d5b5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091686137,
-    "wof:lastmodified":1566648836,
+    "wof:lastmodified":1695886420,
     "wof:name":"Borgne",
     "wof:parent_id":85671961,
     "wof:placetype":"county",

--- a/data/109/168/618/1/1091686181.geojson
+++ b/data/109/168/618/1/1091686181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066711,
-    "geom:area_square_m":782289008.554142,
+    "geom:area_square_m":782289008.554024,
     "geom:bbox":"-74.1160963115,18.3624962147,-73.698680678,18.644422345",
     "geom:latitude":18.495094,
     "geom:longitude":-73.929498,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"HT.GR.CL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879161,
-    "wof:geomhash":"9a1efba95b060273ab5b78b2fb3d7a5d",
+    "wof:geomhash":"8d316df9d2865bd209ac96ea125b4ecf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1091686181,
-    "wof:lastmodified":1566648832,
+    "wof:lastmodified":1695886419,
     "wof:name":"Corail",
     "wof:parent_id":85671933,
     "wof:placetype":"county",

--- a/data/109/168/622/7/1091686227.geojson
+++ b/data/109/168/622/7/1091686227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029806,
-    "geom:area_square_m":347247152.512159,
+    "geom:area_square_m":347247152.512113,
     "geom:bbox":"-71.9763190557,19.4226090721,-71.732458651,19.714466842",
     "geom:latitude":19.579599,
     "geom:longitude":-71.847054,
@@ -126,9 +126,10 @@
     "wof:concordances":{
         "hasc:id":"HT.NE.FL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879163,
-    "wof:geomhash":"5e2d268741d1aa99fbffee51789d6f80",
+    "wof:geomhash":"5997800dcb4a202d9cfe9682ab32e1b3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1091686227,
-    "wof:lastmodified":1566648836,
+    "wof:lastmodified":1695886420,
     "wof:name":"Fort-Libert\u00e9",
     "wof:parent_id":85671957,
     "wof:placetype":"county",

--- a/data/109/168/627/3/1091686273.geojson
+++ b/data/109/168/627/3/1091686273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017815,
-    "geom:area_square_m":207632082.947146,
+    "geom:area_square_m":207632129.627293,
     "geom:bbox":"-72.223677,19.387769,-72.063617,19.624846",
     "geom:latitude":19.518019,
     "geom:longitude":-72.147314,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.ND.GR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879164,
-    "wof:geomhash":"84f2aa58603763d69c0ce5ea249339bb",
+    "wof:geomhash":"d31c263bbd2c9b66ead7c6612bde0f85",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091686273,
-    "wof:lastmodified":1627522190,
+    "wof:lastmodified":1695886669,
     "wof:name":"Grande-Rivi\u00e8re du Nord",
     "wof:parent_id":85671961,
     "wof:placetype":"county",

--- a/data/109/168/631/3/1091686313.geojson
+++ b/data/109/168/631/3/1091686313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110486,
-    "geom:area_square_m":1290654489.948846,
+    "geom:area_square_m":1290654833.850078,
     "geom:bbox":"-72.264104,18.934315,-71.8522,19.333956",
     "geom:latitude":19.140464,
     "geom:longitude":-72.041068,
@@ -128,9 +128,10 @@
     "wof:concordances":{
         "hasc:id":"HT.CE.HI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879166,
-    "wof:geomhash":"37581a2dd9aec1b44561f0b9c421b1b5",
+    "wof:geomhash":"14de6abd76f4d769519b524e9ac763b1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1091686313,
-    "wof:lastmodified":1636495610,
+    "wof:lastmodified":1695886659,
     "wof:name":"Hinche",
     "wof:parent_id":85671955,
     "wof:placetype":"county",

--- a/data/109/168/632/3/1091686323.geojson
+++ b/data/109/168/632/3/1091686323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069278,
-    "geom:area_square_m":812201947.532508,
+    "geom:area_square_m":812201947.532583,
     "geom:bbox":"-74.3872164883,18.3741522075,-74.0711131811,18.675682925",
     "geom:latitude":18.534133,
     "geom:longitude":-74.222392,
@@ -138,9 +138,10 @@
     "wof:concordances":{
         "hasc:id":"HT.GR.JR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879167,
-    "wof:geomhash":"5b3ede9939e6fb4235580cb163f16481",
+    "wof:geomhash":"62b3791dfdea5ccde5c36d7f2c450f7e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1091686323,
-    "wof:lastmodified":1566648834,
+    "wof:lastmodified":1695886420,
     "wof:name":"J\u00e9r\u00e9mie",
     "wof:parent_id":85671933,
     "wof:placetype":"county",

--- a/data/109/168/632/5/1091686325.geojson
+++ b/data/109/168/632/5/1091686325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030882,
-    "geom:area_square_m":359608327.961305,
+    "geom:area_square_m":359608371.791347,
     "geom:bbox":"-72.407883,19.558177,-72.186023,19.783577",
     "geom:latitude":19.656412,
     "geom:longitude":-72.292466,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.ND.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879169,
-    "wof:geomhash":"afd4396b16daf5373ead37ef77d38010",
+    "wof:geomhash":"b79660d277f17ac596b3015bc63e4471",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091686325,
-    "wof:lastmodified":1627522189,
+    "wof:lastmodified":1695886668,
     "wof:name":"l'Acul-du-Nord",
     "wof:parent_id":85671961,
     "wof:placetype":"county",

--- a/data/109/168/632/7/1091686327.geojson
+++ b/data/109/168/632/7/1091686327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052624,
-    "geom:area_square_m":615820929.527556,
+    "geom:area_square_m":615821010.854879,
     "geom:bbox":"-72.709106,18.682361,-72.317108,18.975382",
     "geom:latitude":18.847488,
     "geom:longitude":-72.484224,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.OU.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879170,
-    "wof:geomhash":"f721516384877ef30ecee438cbe5941d",
+    "wof:geomhash":"0f1f0915a09add0948ac7189e16c9d19",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091686327,
-    "wof:lastmodified":1627522190,
+    "wof:lastmodified":1695886669,
     "wof:name":"l'Arcahaie",
     "wof:parent_id":85671967,
     "wof:placetype":"county",

--- a/data/109/168/634/5/1091686345.geojson
+++ b/data/109/168/634/5/1091686345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059221,
-    "geom:area_square_m":693036513.020006,
+    "geom:area_square_m":693036283.74064,
     "geom:bbox":"-73.303816,18.692173,-72.793041,18.970324",
     "geom:latitude":18.841988,
     "geom:longitude":-73.046618,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.OU.LG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879172,
-    "wof:geomhash":"10394deae8e7e4ac69252ac54892b1db",
+    "wof:geomhash":"fb7f06211cf9bd3df64a2b830b0521ad",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091686345,
-    "wof:lastmodified":1627522190,
+    "wof:lastmodified":1695886669,
     "wof:name":"La Gon\u00e2ve",
     "wof:parent_id":85671967,
     "wof:placetype":"county",

--- a/data/109/168/639/3/1091686393.geojson
+++ b/data/109/168/639/3/1091686393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062036,
-    "geom:area_square_m":725995780.508111,
+    "geom:area_square_m":725995780.508172,
     "geom:bbox":"-72.0628851038,18.6851425956,-71.720833514,18.970390847",
     "geom:latitude":18.83741,
     "geom:longitude":-71.867716,
@@ -101,9 +101,10 @@
     "wof:concordances":{
         "hasc:id":"HT.CE.LC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879173,
-    "wof:geomhash":"2dee89637441a219e60b7cd668eb82ba",
+    "wof:geomhash":"ed8a10982acaa496dd0afc6448ee2af4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091686393,
-    "wof:lastmodified":1566648838,
+    "wof:lastmodified":1695886421,
     "wof:name":"Lascahobas",
     "wof:parent_id":85671955,
     "wof:placetype":"county",

--- a/data/109/168/643/1/1091686431.geojson
+++ b/data/109/168/643/1/1091686431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02101,
-    "geom:area_square_m":244597344.899684,
+    "geom:area_square_m":244597322.063982,
     "geom:bbox":"-72.259854,19.587564,-72.036129,19.7889",
     "geom:latitude":19.690998,
     "geom:longitude":-72.147237,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.ND.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879175,
-    "wof:geomhash":"129719dad4a9ed01ac3c80e13cd139f2",
+    "wof:geomhash":"f5a75c761a77d2e3e569ce47091677f2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091686431,
-    "wof:lastmodified":1627522190,
+    "wof:lastmodified":1695886669,
     "wof:name":"le Cap-Ha\u00eftien",
     "wof:parent_id":85671961,
     "wof:placetype":"county",

--- a/data/109/168/647/9/1091686479.geojson
+++ b/data/109/168/647/9/1091686479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073785,
-    "geom:area_square_m":866320687.704031,
+    "geom:area_square_m":866320687.703698,
     "geom:bbox":"-74.0475487432,18.056131757,-73.571320139,18.4245161778",
     "geom:latitude":18.281166,
     "geom:longitude":-73.831629,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"HT.SD.CY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879176,
-    "wof:geomhash":"f7531634fa101c3a63407a623a18ae56",
+    "wof:geomhash":"ac11ff5d579811a39c3e888da3405133",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1091686479,
-    "wof:lastmodified":1566648837,
+    "wof:lastmodified":1695886421,
     "wof:name":"les Cayes",
     "wof:parent_id":85671947,
     "wof:placetype":"county",

--- a/data/109/168/650/3/1091686503.geojson
+++ b/data/109/168/650/3/1091686503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032539,
-    "geom:area_square_m":381911867.718409,
+    "geom:area_square_m":381911916.491185,
     "geom:bbox":"-74.450458,18.25171,-74.037254,18.407375",
     "geom:latitude":18.339786,
     "geom:longitude":-74.209317,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.SD.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879178,
-    "wof:geomhash":"dcddc1d480069abedbb01e28e4a3a8b6",
+    "wof:geomhash":"8351595fba07a9b9e672935402a3bb0f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091686503,
-    "wof:lastmodified":1627522190,
+    "wof:lastmodified":1695886669,
     "wof:name":"les Chardonni\u00e8res",
     "wof:parent_id":85671947,
     "wof:placetype":"county",

--- a/data/109/168/654/3/1091686543.geojson
+++ b/data/109/168/654/3/1091686543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015054,
-    "geom:area_square_m":176786373.229391,
+    "geom:area_square_m":176786441.342388,
     "geom:bbox":"-74.107199,18.13157,-73.941892,18.331633",
     "geom:latitude":18.24254,
     "geom:longitude":-74.024414,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.SD.CX"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879179,
-    "wof:geomhash":"f30d053027648e327483309272bb67b0",
+    "wof:geomhash":"5aa4af3fba26682aacab7bc08ec4ccbf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091686543,
-    "wof:lastmodified":1627522190,
+    "wof:lastmodified":1695886669,
     "wof:name":"les C\u00f4teaux",
     "wof:parent_id":85671947,
     "wof:placetype":"county",

--- a/data/109/168/658/3/1091686583.geojson
+++ b/data/109/168/658/3/1091686583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061493,
-    "geom:area_square_m":717328700.477285,
+    "geom:area_square_m":717328700.477193,
     "geom:bbox":"-72.4976105702,19.2059122012,-72.2012634203,19.5905272897",
     "geom:latitude":19.370991,
     "geom:longitude":-72.344586,
@@ -98,9 +98,10 @@
     "wof:concordances":{
         "hasc:id":"HT.AR.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879181,
-    "wof:geomhash":"0e793df5d01348c1b5b209be4bc0c041",
+    "wof:geomhash":"875f7beef9d7adb500953496218c8c6a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091686583,
-    "wof:lastmodified":1566648833,
+    "wof:lastmodified":1695886420,
     "wof:name":"Marmelade",
     "wof:parent_id":85671949,
     "wof:placetype":"county",

--- a/data/109/168/662/9/1091686629.geojson
+++ b/data/109/168/662/9/1091686629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034932,
-    "geom:area_square_m":409869783.408161,
+    "geom:area_square_m":409869783.408095,
     "geom:bbox":"-73.3381779094,18.2320742037,-72.9912561422,18.489703751",
     "geom:latitude":18.394568,
     "geom:longitude":-73.148928,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"HT.NI.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879183,
-    "wof:geomhash":"f38cfe87d775052b2098ce282b2b4a1f",
+    "wof:geomhash":"aae37045e4bfb42fd63b6bbca83f3eec",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1091686629,
-    "wof:lastmodified":1566648838,
+    "wof:lastmodified":1695886421,
     "wof:name":"Mirago\u00e2ne",
     "wof:parent_id":85671937,
     "wof:placetype":"county",

--- a/data/109/168/667/3/1091686673.geojson
+++ b/data/109/168/667/3/1091686673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073182,
-    "geom:area_square_m":856306534.365887,
+    "geom:area_square_m":856306534.36593,
     "geom:bbox":"-72.363693351,18.6958689414,-71.9453139808,19.0817723663",
     "geom:latitude":18.86415,
     "geom:longitude":-72.142488,
@@ -101,9 +101,10 @@
     "wof:concordances":{
         "hasc:id":"HT.CE.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879184,
-    "wof:geomhash":"63d18001107e4175dd8ecf66aa51901c",
+    "wof:geomhash":"9194b511abbd62b3f8ec524a4c3f083e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091686673,
-    "wof:lastmodified":1566648834,
+    "wof:lastmodified":1695886420,
     "wof:name":"Mirebalais",
     "wof:parent_id":85671955,
     "wof:placetype":"county",

--- a/data/109/168/669/1/1091686691.geojson
+++ b/data/109/168/669/1/1091686691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022114,
-    "geom:area_square_m":257524741.533002,
+    "geom:area_square_m":257524674.133571,
     "geom:bbox":"-72.64849,19.520278,-72.41602,19.771855",
     "geom:latitude":19.64589,
     "geom:longitude":-72.517724,
@@ -116,9 +116,10 @@
     "wof:concordances":{
         "hasc:id":"HT.ND.PL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879186,
-    "wof:geomhash":"fb3e2136732d9d251f7250d69f4b9b5f",
+    "wof:geomhash":"3e71b4d2c01b93bb98eea4514721f8c0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1091686691,
-    "wof:lastmodified":1636495610,
+    "wof:lastmodified":1695886659,
     "wof:name":"Plaisance",
     "wof:parent_id":85671961,
     "wof:placetype":"county",

--- a/data/109/168/673/5/1091686735.geojson
+++ b/data/109/168/673/5/1091686735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06193,
-    "geom:area_square_m":726326418.949775,
+    "geom:area_square_m":726326418.949702,
     "geom:bbox":"-72.569360017,18.3404142847,-72.1592115412,18.630376773",
     "geom:latitude":18.471207,
     "geom:longitude":-72.340172,
@@ -366,9 +366,10 @@
     "wof:concordances":{
         "hasc:id":"HT.OU.PP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879187,
-    "wof:geomhash":"1ea7a466862d2d43701f52f4f372d3b5",
+    "wof:geomhash":"6de602592b048326c8ab972b35a4f2d3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -378,7 +379,7 @@
         }
     ],
     "wof:id":1091686735,
-    "wof:lastmodified":1566648832,
+    "wof:lastmodified":1695886419,
     "wof:name":"Port-au-Prince",
     "wof:parent_id":85671967,
     "wof:placetype":"county",

--- a/data/109/168/678/1/1091686781.geojson
+++ b/data/109/168/678/1/1091686781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069288,
-    "geom:area_square_m":805710007.352836,
+    "geom:area_square_m":805710007.352932,
     "geom:bbox":"-73.0332438757,19.7089639263,-72.620123003,20.089226782",
     "geom:latitude":19.877901,
     "geom:longitude":-72.862129,
@@ -126,9 +126,10 @@
     "wof:concordances":{
         "hasc:id":"HT.NO.PD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879189,
-    "wof:geomhash":"c128035325bdae7d2b34e13953edd445",
+    "wof:geomhash":"5510db0ef5c33fa61af136802e8bce00",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1091686781,
-    "wof:lastmodified":1566648838,
+    "wof:lastmodified":1695886421,
     "wof:name":"Port-de-Paix",
     "wof:parent_id":85671941,
     "wof:placetype":"county",

--- a/data/109/168/680/7/1091686807.geojson
+++ b/data/109/168/680/7/1091686807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015855,
-    "geom:area_square_m":184379237.119131,
+    "geom:area_square_m":184379233.686321,
     "geom:bbox":"-72.770789,19.807487,-72.564154,19.943703",
     "geom:latitude":19.873294,
     "geom:longitude":-72.678469,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.NO.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879190,
-    "wof:geomhash":"527269f2bba3659730e1b3e981ad6cd1",
+    "wof:geomhash":"7221d2b37e541f19994e4bb331eb8074",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091686807,
-    "wof:lastmodified":1627522191,
+    "wof:lastmodified":1695886670,
     "wof:name":"Saint-Louis du Nord",
     "wof:parent_id":85671941,
     "wof:placetype":"county",

--- a/data/109/168/685/5/1091686855.geojson
+++ b/data/109/168/685/5/1091686855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090215,
-    "geom:area_square_m":1054443766.783363,
+    "geom:area_square_m":1054443766.782831,
     "geom:bbox":"-72.823678228,18.8579718431,-72.2424869992,19.2558601672",
     "geom:latitude":19.047951,
     "geom:longitude":-72.570634,
@@ -125,9 +125,10 @@
     "wof:concordances":{
         "hasc:id":"HT.AR.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879192,
-    "wof:geomhash":"eb7979f2a4e57bf7753c7ce36a2a7b9a",
+    "wof:geomhash":"6beaf4a5ac78b6b4b6a39b640324e853",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1091686855,
-    "wof:lastmodified":1566648837,
+    "wof:lastmodified":1695886421,
     "wof:name":"Saint-Marc",
     "wof:parent_id":85671949,
     "wof:placetype":"county",

--- a/data/109/168/689/5/1091686895.geojson
+++ b/data/109/168/689/5/1091686895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026202,
-    "geom:area_square_m":305503433.42537,
+    "geom:area_square_m":305503433.425383,
     "geom:bbox":"-72.329852713,19.2815705169,-72.1310979274,19.5803830381",
     "geom:latitude":19.449748,
     "geom:longitude":-72.22425,
@@ -111,9 +111,10 @@
     "wof:concordances":{
         "hasc:id":"HT.ND.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879193,
-    "wof:geomhash":"b3f43da085045d365849029e5cb28f01",
+    "wof:geomhash":"e58819efd7b9d5627032ea3fcb91e9e0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1091686895,
-    "wof:lastmodified":1566648831,
+    "wof:lastmodified":1695886419,
     "wof:name":"Saint-Rapha\u00ebl",
     "wof:parent_id":85671961,
     "wof:placetype":"county",

--- a/data/109/168/692/1/1091686921.geojson
+++ b/data/109/168/692/1/1091686921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095273,
-    "geom:area_square_m":1108627197.74689,
+    "geom:area_square_m":1108627020.875646,
     "geom:bbox":"-73.45576,19.622552,-72.999487,19.930387",
     "geom:latitude":19.770574,
     "geom:longitude":-73.223881,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.NO.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879195,
-    "wof:geomhash":"6ba011fe9dab1dc03a4eba3de8b1dc20",
+    "wof:geomhash":"36dc21c3038c2c66c5dcb5b18e9e3617",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091686921,
-    "wof:lastmodified":1627522191,
+    "wof:lastmodified":1695886670,
     "wof:name":"M\u00f4le Saint-Nicolas",
     "wof:parent_id":85671941,
     "wof:placetype":"county",

--- a/data/109/168/698/1/1091686981.geojson
+++ b/data/109/168/698/1/1091686981.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086985,
-    "geom:area_square_m":1012886002.681243,
+    "geom:area_square_m":1012885877.758407,
     "geom:bbox":"-73.135469,19.50146,-72.572687,19.81523",
     "geom:latitude":19.660366,
     "geom:longitude":-72.830888,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.AR.GM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879197,
-    "wof:geomhash":"4f248577ebc03265e898600689ef1472",
+    "wof:geomhash":"4d211a8aa4330a1bbbbbb94deb406060",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091686981,
-    "wof:lastmodified":1627522190,
+    "wof:lastmodified":1695886669,
     "wof:name":"Gros-Morne",
     "wof:parent_id":85671949,
     "wof:placetype":"county",

--- a/data/109/168/702/5/1091687025.geojson
+++ b/data/109/168/702/5/1091687025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082048,
-    "geom:area_square_m":956533542.153771,
+    "geom:area_square_m":956533443.423596,
     "geom:bbox":"-72.805397,19.298938,-72.371398,19.648657",
     "geom:latitude":19.467723,
     "geom:longitude":-72.59331,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.AR.GV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879198,
-    "wof:geomhash":"125f2e79088d03d27762004822aa5b1b",
+    "wof:geomhash":"e61c0f85cd05e29940317dafc5e512ec",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091687025,
-    "wof:lastmodified":1627522190,
+    "wof:lastmodified":1695886669,
     "wof:name":"les Gona\u00efves",
     "wof:parent_id":85671949,
     "wof:placetype":"county",

--- a/data/109/168/705/7/1091687057.geojson
+++ b/data/109/168/705/7/1091687057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014814,
-    "geom:area_square_m":172463258.877319,
+    "geom:area_square_m":172463264.839225,
     "geom:bbox":"-72.464705,19.566598,-72.342024,19.817262",
     "geom:latitude":19.68931,
     "geom:longitude":-72.405196,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.ND.LL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879200,
-    "wof:geomhash":"d45b54b5c2270cc368bfc216262237f8",
+    "wof:geomhash":"1d06035c5a335eb942596ce82b933b8e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091687057,
-    "wof:lastmodified":1627522190,
+    "wof:lastmodified":1695886670,
     "wof:name":"le Limb\u00e9",
     "wof:parent_id":85671961,
     "wof:placetype":"county",

--- a/data/109/168/709/9/1091687099.geojson
+++ b/data/109/168/709/9/1091687099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04321,
-    "geom:area_square_m":503331458.270037,
+    "geom:area_square_m":503331548.552838,
     "geom:bbox":"-72.121824,19.429326,-71.845697,19.734837",
     "geom:latitude":19.601768,
     "geom:longitude":-71.995421,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.NE.TN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879201,
-    "wof:geomhash":"dc78957c95893bca9dd4488ef09bf379",
+    "wof:geomhash":"941077b0f9079b76beda890c9d1f89fc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091687099,
-    "wof:lastmodified":1627522191,
+    "wof:lastmodified":1695886670,
     "wof:name":"le Trou-du-Nord",
     "wof:parent_id":85671957,
     "wof:placetype":"county",

--- a/data/109/168/711/7/1091687117.geojson
+++ b/data/109/168/711/7/1091687117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03155,
-    "geom:area_square_m":367832455.047575,
+    "geom:area_square_m":367832455.047624,
     "geom:bbox":"-71.8587582408,19.3321429449,-71.678483598,19.5933044737",
     "geom:latitude":19.460646,
     "geom:longitude":-71.76621,
@@ -101,9 +101,10 @@
     "wof:concordances":{
         "hasc:id":"HT.NE.OU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879203,
-    "wof:geomhash":"0d649f95d5632184c5c508e06b122efe",
+    "wof:geomhash":"538c207faea2e11ed673fa6121091cdd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091687117,
-    "wof:lastmodified":1566648840,
+    "wof:lastmodified":1695886422,
     "wof:name":"Ouanaminthe",
     "wof:parent_id":85671957,
     "wof:placetype":"county",

--- a/data/109/168/711/9/1091687119.geojson
+++ b/data/109/168/711/9/1091687119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035391,
-    "geom:area_square_m":412833318.231107,
+    "geom:area_square_m":412833318.231024,
     "geom:bbox":"-72.0359490374,19.2606462132,-71.753264584,19.5239381613",
     "geom:latitude":19.377031,
     "geom:longitude":-71.905831,
@@ -105,9 +105,10 @@
     "wof:concordances":{
         "hasc:id":"HT.NE.VR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879204,
-    "wof:geomhash":"0558ea720697497af829132509280b51",
+    "wof:geomhash":"7fcbc4d3a97ee514028ae67f66c98415",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1091687119,
-    "wof:lastmodified":1566648840,
+    "wof:lastmodified":1695886422,
     "wof:name":"Valli\u00e8res",
     "wof:parent_id":85671957,
     "wof:placetype":"county",

--- a/data/109/168/712/3/1091687123.geojson
+++ b/data/109/168/712/3/1091687123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051414,
-    "geom:area_square_m":600587927.317789,
+    "geom:area_square_m":600587874.850462,
     "geom:bbox":"-71.918125,18.976567,-71.622151,19.279755",
     "geom:latitude":19.143231,
     "geom:longitude":-71.779131,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.CE.CS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879206,
-    "wof:geomhash":"4dcd6d1ae8e57d650ffa57f3fa8db8d1",
+    "wof:geomhash":"30cc3ea5c81f76450c4821f1d52bf611",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091687123,
-    "wof:lastmodified":1627522190,
+    "wof:lastmodified":1695886670,
     "wof:name":"Cerca la Source",
     "wof:parent_id":85671955,
     "wof:placetype":"county",

--- a/data/109/168/712/7/1091687127.geojson
+++ b/data/109/168/712/7/1091687127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096764,
-    "geom:area_square_m":1130206092.382069,
+    "geom:area_square_m":1130206092.381961,
     "geom:bbox":"-72.775032454,18.9159604565,-72.2207216086,19.375984102",
     "geom:latitude":19.162026,
     "geom:longitude":-72.444938,
@@ -101,9 +101,10 @@
     "wof:concordances":{
         "hasc:id":"HT.AR.DS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879207,
-    "wof:geomhash":"9e745b16d38fe5e9b77635b7e232b1d7",
+    "wof:geomhash":"cc1c592fd6fec758fa36abb98eee7711",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091687127,
-    "wof:lastmodified":1566648835,
+    "wof:lastmodified":1695886420,
     "wof:name":"Dessalines",
     "wof:parent_id":85671949,
     "wof:placetype":"county",

--- a/data/109/168/717/1/1091687171.geojson
+++ b/data/109/168/717/1/1091687171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060969,
-    "geom:area_square_m":715808737.164435,
+    "geom:area_square_m":715808693.293646,
     "geom:bbox":"-72.652689,18.171361,-72.22147,18.405605",
     "geom:latitude":18.290952,
     "geom:longitude":-72.448365,
@@ -149,9 +149,10 @@
     "wof:concordances":{
         "hasc:id":"HT.SE.JC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879209,
-    "wof:geomhash":"f5a1bbe9d58be266cfb0aefdd39aa583",
+    "wof:geomhash":"63de2e26f72edb1b9816cc8e863aa7d1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":1091687171,
-    "wof:lastmodified":1636495610,
+    "wof:lastmodified":1695886659,
     "wof:name":"Jacmel",
     "wof:parent_id":85671969,
     "wof:placetype":"county",

--- a/data/109/168/719/9/1091687199.geojson
+++ b/data/109/168/719/9/1091687199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085928,
-    "geom:area_square_m":1008217032.300252,
+    "geom:area_square_m":1008217032.300208,
     "geom:bbox":"-73.0545118963,18.2594587633,-72.4497912045,18.565303412",
     "geom:latitude":18.395734,
     "geom:longitude":-72.758205,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"HT.OU.LN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879210,
-    "wof:geomhash":"1aaaae7cb30e941cc5ca051e2a1d7d1c",
+    "wof:geomhash":"46cd59c9e3d6d0344e09c4d764519d7e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1091687199,
-    "wof:lastmodified":1566648839,
+    "wof:lastmodified":1695886421,
     "wof:name":"L\u00e9og\u00e2ne",
     "wof:parent_id":85671967,
     "wof:placetype":"county",

--- a/data/109/168/724/1/1091687241.geojson
+++ b/data/109/168/724/1/1091687241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069789,
-    "geom:area_square_m":818589454.430339,
+    "geom:area_square_m":818589627.882932,
     "geom:bbox":"-73.780711,18.335768,-73.25557,18.589305",
     "geom:latitude":18.451425,
     "geom:longitude":-73.51342,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"HT.NI.AV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879212,
-    "wof:geomhash":"7680c9e77a35b40da5c0366b8f2633d4",
+    "wof:geomhash":"aa2c6456d91b50a40a8e5ba7260b507d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091687241,
-    "wof:lastmodified":1627522189,
+    "wof:lastmodified":1695886669,
     "wof:name":"l'Anse-\u00e0-Veau",
     "wof:parent_id":85671937,
     "wof:placetype":"county",

--- a/data/109/168/729/3/1091687293.geojson
+++ b/data/109/168/729/3/1091687293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08968,
-    "geom:area_square_m":1052853850.21833,
+    "geom:area_square_m":1052853850.21861,
     "geom:bbox":"-73.6989420056,18.181608872,-73.0062644166,18.4320749149",
     "geom:latitude":18.294881,
     "geom:longitude":-73.362588,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"HT.SD.AQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879213,
-    "wof:geomhash":"8ad95316de2138afff0145c7fa249bd7",
+    "wof:geomhash":"0315d11ed552040f1cf811412bba5fe5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091687293,
-    "wof:lastmodified":1566648840,
+    "wof:lastmodified":1695886422,
     "wof:name":"Aquin",
     "wof:parent_id":85671947,
     "wof:placetype":"county",

--- a/data/109/168/732/9/1091687329.geojson
+++ b/data/109/168/732/9/1091687329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015093,
-    "geom:area_square_m":177393317.54666,
+    "geom:area_square_m":177393317.546733,
     "geom:bbox":"-73.9498365839,18.022139955,-73.782878082,18.195028339",
     "geom:latitude":18.095406,
     "geom:longitude":-73.879294,
@@ -110,9 +110,10 @@
     "wof:concordances":{
         "hasc:id":"HT.SD.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879215,
-    "wof:geomhash":"d4fe6520b93f10fb4779ff89f6af2bda",
+    "wof:geomhash":"2d51e31dc8e82283b7efa09a4e152515",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1091687329,
-    "wof:lastmodified":1566648836,
+    "wof:lastmodified":1695886421,
     "wof:name":"Port-Salut",
     "wof:parent_id":85671947,
     "wof:placetype":"county",

--- a/data/109/168/737/9/1091687379.geojson
+++ b/data/109/168/737/9/1091687379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.166085,
-    "geom:area_square_m":1947134250.674346,
+    "geom:area_square_m":1947134250.674258,
     "geom:bbox":"-72.3562345587,18.274190489,-71.695262477,18.8177870861",
     "geom:latitude":18.535826,
     "geom:longitude":-72.050874,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"HT.OU.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HT",
     "wof:created":1473879217,
-    "wof:geomhash":"72d1dc6cb2040018a99b8a3f3f837a1b",
+    "wof:geomhash":"758b87ea5af7eb500732c5a50369748b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1091687379,
-    "wof:lastmodified":1566648830,
+    "wof:lastmodified":1695886418,
     "wof:name":"Croix-des-Bouquets",
     "wof:parent_id":85671967,
     "wof:placetype":"county",

--- a/data/856/324/33/85632433.geojson
+++ b/data/856/324/33/85632433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.328067,
-    "geom:area_square_m":27227809547.380165,
+    "geom:area_square_m":27227809547.383404,
     "geom:bbox":"-74.482941,18.020416,-71.62181,20.088388",
     "geom:latitude":18.936379,
     "geom:longitude":-72.688703,
@@ -14,6 +14,9 @@
     "iso:country":"HT",
     "itu:country_code":[
         "509"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "country"
     ],
     "label:eng_x_preferred_shortcode":[
         "HT"
@@ -1111,7 +1114,8 @@
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"wk",
+    "src:population":"naturalearth",
+    "src:population_year":"2019",
     "statoids:dial":"509",
     "statoids:ds":"RH",
     "statoids:fifa":"HAI",
@@ -1170,7 +1174,7 @@
         "meso",
         "naturalearth"
     ],
-    "wof:geomhash":"481c582db21ab9d7be63756afebc65c4",
+    "wof:geomhash":"6063b26d4dde2268d26efd5b34382418",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -1186,12 +1190,12 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1690930590,
+    "wof:lastmodified":1694492054,
     "wof:name":"Haiti",
     "wof:parent_id":102191575,
     "wof:placetype":"country",
-    "wof:population":10317461,
-    "wof:population_rank":14,
+    "wof:population":11263077,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-ht",
     "wof:shortcode":"HT",
     "wof:superseded_by":[],

--- a/data/856/324/33/85632433.geojson
+++ b/data/856/324/33/85632433.geojson
@@ -1115,7 +1115,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"naturalearth",
-    "src:population_year":"2019",
+    "src:population_date":"2019",
     "statoids:dial":"509",
     "statoids:ds":"RH",
     "statoids:fifa":"HAI",
@@ -1190,7 +1190,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1694492054,
+    "wof:lastmodified":1694639508,
     "wof:name":"Haiti",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/324/33/85632433.geojson
+++ b/data/856/324/33/85632433.geojson
@@ -1153,6 +1153,7 @@
         "hasc:id":"HT",
         "icao:code":"HH",
         "ioc:id":"HAI",
+        "iso:code":"HT",
         "itu:id":"HTI",
         "loc:id":"n79053108",
         "m49:code":"332",
@@ -1167,6 +1168,7 @@
         "wk:page":"Haiti",
         "wmo:id":"HA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HT",
     "wof:country_alpha3":"HTI",
     "wof:geom_alt":[
@@ -1190,7 +1192,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1694639508,
+    "wof:lastmodified":1695881163,
     "wof:name":"Haiti",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/719/33/85671933.geojson
+++ b/data/856/719/33/85671933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.163818,
-    "geom:area_square_m":1920882763.013866,
+    "geom:area_square_m":1920882597.516289,
     "geom:bbox":"-74.4804,18.356304,-73.698681,18.675683",
     "geom:latitude":18.50671,
     "geom:longitude":-74.13176,
@@ -311,15 +311,17 @@
         "gn:id":3724613,
         "gp:id":2345617,
         "hasc:id":"HT.GR",
+        "iso:code":"HT-GA",
         "iso:id":"HT-GA",
         "qs_pg:id":1135069,
         "wd:id":"Q913231"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5d463242bb2c4a2ddd39734ddb8aeafa",
+    "wof:geomhash":"5e475064f3b9c71694a9dd60b5fdfeaf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -336,7 +338,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1690930592,
+    "wof:lastmodified":1695884801,
     "wof:name":"Grand'Anse",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/37/85671937.geojson
+++ b/data/856/719/37/85671937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.104721,
-    "geom:area_square_m":1228459420.435437,
+    "geom:area_square_m":1228459971.999656,
     "geom:bbox":"-73.780711,18.232074,-72.991256,18.589305",
     "geom:latitude":18.432459,
     "geom:longitude":-73.391835,
@@ -291,15 +291,17 @@
         "gn:id":7115999,
         "gp:id":-2345617,
         "hasc:id":"HT.NI",
+        "iso:code":"HT-NI",
         "iso:id":"HT-NI",
         "unlc:id":"HT-NI",
         "wd:id":"Q125232"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"731ddce968669b72642b8bdddd36aa72",
+    "wof:geomhash":"abcf610b124e32fb72c72d54f4eb68d5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -316,7 +318,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1690930592,
+    "wof:lastmodified":1695884801,
     "wof:name":"Nippes",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/41/85671941.geojson
+++ b/data/856/719/41/85671941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.180416,
-    "geom:area_square_m":2098716442.219029,
+    "geom:area_square_m":2098716464.705548,
     "geom:bbox":"-73.45576,19.622552,-72.564154,20.089227",
     "geom:latitude":19.820819,
     "geom:longitude":-73.03702,
@@ -289,17 +289,19 @@
         "gn:id":3719536,
         "gp:id":2345614,
         "hasc:id":"HT.NO",
+        "iso:code":"HT-NO",
         "iso:id":"HT-NO",
         "qs_pg:id":219560,
         "unlc:id":"HT-NO",
         "wd:id":"Q608361",
         "wk:page":"Nord-Ouest (department)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5685a140ef94939873cf7d6bac4778c4",
+    "wof:geomhash":"6d15370ea4f158ba33781f3def633c3d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -316,7 +318,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1690930593,
+    "wof:lastmodified":1695884801,
     "wof:name":"Nord-Ouest",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/47/85671947.geojson
+++ b/data/856/719/47/85671947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.22615,
-    "geom:area_square_m":2655266096.417336,
+    "geom:area_square_m":2655266188.005579,
     "geom:bbox":"-74.450458,18.02214,-73.006264,18.432075",
     "geom:latitude":18.280071,
     "geom:longitude":-73.715987,
@@ -301,16 +301,18 @@
         "gn:id":3716952,
         "gp:id":2345621,
         "hasc:id":"HT.SD",
+        "iso:code":"HT-SD",
         "iso:id":"HT-SD",
         "qs_pg:id":191347,
         "wd:id":"Q936704",
         "wk:page":"Sud (department)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"57d00ee52f07059ec0a539bb49322dbc",
+    "wof:geomhash":"3bdbe008a8f4b7763126a8e23b1a6d38",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -327,7 +329,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1690930594,
+    "wof:lastmodified":1695884801,
     "wof:name":"Sud",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/49/85671949.geojson
+++ b/data/856/719/49/85671949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.417505,
-    "geom:area_square_m":4871398381.664413,
+    "geom:area_square_m":4871398256.043204,
     "geom:bbox":"-73.135469,18.857972,-72.201263,19.81523",
     "geom:latitude":19.332057,
     "geom:longitude":-72.566887,
@@ -289,17 +289,19 @@
         "gn:id":3731053,
         "gp:id":2345615,
         "hasc:id":"HT.AR",
+        "iso:code":"HT-AR",
         "iso:id":"HT-AR",
         "qs_pg:id":1083836,
         "unlc:id":"HT-AR",
         "wd:id":"Q844024",
         "wk:page":"Artibonite (department)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f9e1c9b371b4378cff96164852e6031d",
+    "wof:geomhash":"36a075d4fb04099eed64fd7dbca04763",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -316,7 +318,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1690930593,
+    "wof:lastmodified":1695884802,
     "wof:name":"L'Artibonite",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/55/85671955.geojson
+++ b/data/856/719/55/85671955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.297118,
-    "geom:area_square_m":3473544912.242562,
+    "geom:area_square_m":3473544856.092705,
     "geom:bbox":"-72.363693,18.685143,-71.622151,19.333956",
     "geom:latitude":19.00961,
     "geom:longitude":-71.984528,
@@ -296,17 +296,19 @@
         "gn:id":3728069,
         "gp:id":2345616,
         "hasc:id":"HT.CE",
+        "iso:code":"HT-CE",
         "iso:id":"HT-CE",
         "qs_pg:id":318499,
         "unlc:id":"HT-CE",
         "wd:id":"Q844528",
         "wk:page":"Centre (department)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8de2bc8a1d70073f399c59f22b0b984c",
+    "wof:geomhash":"b42f7c9d36c4c5cd5026e2e7c7ad569d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -323,7 +325,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1690930593,
+    "wof:lastmodified":1695884801,
     "wof:name":"Centre",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/57/85671957.geojson
+++ b/data/856/719/57/85671957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.139957,
-    "geom:area_square_m":1631244494.467325,
+    "geom:area_square_m":1631244636.928134,
     "geom:bbox":"-72.121824,19.260646,-71.678484,19.734837",
     "geom:latitude":19.508404,
     "geom:longitude":-71.889499,
@@ -284,17 +284,19 @@
         "gn:id":3719540,
         "gp:id":2345619,
         "hasc:id":"HT.NE",
+        "iso:code":"HT-NE",
         "iso:id":"HT-NE",
         "qs_pg:id":1046741,
         "unlc:id":"HT-NE",
         "wd:id":"Q928694",
         "wk:page":"Nord-Est (department)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"65d189bc068a3969e870c4aba6570842",
+    "wof:geomhash":"d92fec435e9262cf94772ec5b28560ff",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -311,7 +313,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1690930591,
+    "wof:lastmodified":1695884800,
     "wof:name":"Nord-Est",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/61/85671961.geojson
+++ b/data/856/719/61/85671961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.181255,
-    "geom:area_square_m":2111382122.328958,
+    "geom:area_square_m":2111381791.57078,
     "geom:bbox":"-72.682635,19.255451,-71.973762,19.881682",
     "geom:latitude":19.599879,
     "geom:longitude":-72.297218,
@@ -298,16 +298,18 @@
         "gn:id":3719543,
         "gp:id":2345618,
         "hasc:id":"HT.ND",
+        "iso:code":"HT-ND",
         "iso:id":"HT-ND",
         "qs_pg:id":235598,
         "wd:id":"Q943932",
         "wk:page":"Nord (Haitian department)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"af3e9b1e207085c5f72e3b3760b9edc2",
+    "wof:geomhash":"67a02cb48396e7cdb6824fd8957db6ac",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -324,7 +326,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1690930590,
+    "wof:lastmodified":1695884800,
     "wof:name":"Nord",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/67/85671967.geojson
+++ b/data/856/719/67/85671967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.425788,
-    "geom:area_square_m":4990535208.221437,
+    "geom:area_square_m":4990535064.034204,
     "geom:bbox":"-73.303816,18.259459,-71.695262,18.975382",
     "geom:latitude":18.579257,
     "geom:longitude":-72.42775,
@@ -311,16 +311,18 @@
         "gn:id":3719432,
         "gp:id":2345620,
         "hasc:id":"HT.OU",
+        "iso:code":"HT-OU",
         "iso:id":"HT-OU",
         "qs_pg:id":1168660,
         "wd:id":"Q1434621",
         "wk:page":"Ouest (department)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dc0e49dc16a005bc7abfc06eb8d981e0",
+    "wof:geomhash":"33f2af519082a54188e20ab252d31de0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -337,7 +339,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1690930591,
+    "wof:lastmodified":1695884801,
     "wof:name":"Ouest",
     "wof:parent_id":85632433,
     "wof:placetype":"region",

--- a/data/856/719/69/85671969.geojson
+++ b/data/856/719/69/85671969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.174196,
-    "geom:area_square_m":2045571173.501418,
+    "geom:area_square_m":2045571038.929863,
     "geom:bbox":"-73.015579,18.031698,-71.726933,18.405605",
     "geom:latitude":18.254199,
     "geom:longitude":-72.366711,
@@ -296,17 +296,19 @@
         "gn:id":3716950,
         "gp:id":2345622,
         "hasc:id":"HT.SE",
+        "iso:code":"HT-SE",
         "iso:id":"HT-SE",
         "qs_pg:id":453303,
         "unlc:id":"HT-SE",
         "wd:id":"Q936717",
         "wk:page":"Sud-Est (department)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f9bd01263e45062203e667f79c859f79",
+    "wof:geomhash":"8e4d9f31f8385a31a81251bb1eee327e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -323,7 +325,7 @@
         "hat",
         "fra"
     ],
-    "wof:lastmodified":1690930591,
+    "wof:lastmodified":1695884801,
     "wof:name":"Sud-Est",
     "wof:parent_id":85632433,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.